### PR TITLE
Changed references from old Repo to new Repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@ Anticipated release: August 10, 2020
 
 # Previous releases
 
-See our [release history](https://github.com/18F/cms-hitech-apd/releases)
+See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-[#2335]: https://github.com/18F/cms-hitech-apd/issues/2335
+[#2335]: https://github.com/CMSgov/eAPD/issues/2335

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build status](https://img.shields.io/circleci/project/github/18F/cms-hitech-apd.svg)](https://circleci.com/gh/18F/workflows/cms-hitech-apd)
-[![Test coverage](https://img.shields.io/codecov/c/github/18F/cms-hitech-apd.svg)](https://codecov.io/gh/18F/cms-hitech-apd)
+[![Build status](https://img.shields.io/circleci/project/github/CMSgov/eAPD.svg)](https://circleci.com/gh/CMSgov/workflows/eAPD)
+[![Test coverage](https://img.shields.io/codecov/c/github/CMSgov/eAPD.svg)](https://codecov.io/gh/CMSgov/eAPD)
 ![Node.js >= 10.14](https://img.shields.io/badge/node-%3E%3D%2010.14-brightgreen.svg)
 
 # CMS eAPD app
@@ -10,7 +10,7 @@ associated contract documents. It is currently limited to HITECH but may
 potentially be expanded to other Medicaid programs in the future.
 
 _Please note:_ Any content contained in screenshots from the application within
-the `cms-hitech-apd` repo should be considered test data being used for
+the `eAPD` repo should be considered test data being used for
 development purposes ONLY. Project, financial, and timeline information is NOT
 representative of any production data from actual users.
 
@@ -29,17 +29,17 @@ you have your SSH keys configured, you'll clone from the SSH link. You can
 find the link by clicking the green "Clone or download" button above the file
 listing on this page.
 
-The HTTPS link is https://github.com/18F/cms-hitech-apd.git
+The HTTPS link is https://github.com/CMSgov/eAPD.git
 
 If you're familiar with git and just want to work from the command line, you
 just need to run:
 
 ```shell
-git clone https://github.com/18F/cms-hitech-apd.git
+git clone https://github.com/CMSgov/eAPD.git
 ```
 
 If you can't use git for some reason, you can also download the most recent
-code as [a ZIP file](https://github.com/18F/cms-hitech-apd/archive/master.zip).
+code as [a ZIP file](https://github.com/CMSgov/eAPD/archive/master.zip).
 
 ### Making it run
 
@@ -47,9 +47,9 @@ We recommend using [Docker](https://www.docker.com) to run the app locally. We
 provide a Docker configuration that will quickly install and build everything
 you need, so don't have to. It'll also take care of getting everything running
 and connected. For more details,
-[see our wiki](https://github.com/18F/cms-hitech-apd/wiki/Development-Environment#docker).
+[see our wiki](https://github.com/CMSgov/eAPD/wiki/Development-Environment#docker).
 If you don't have or can't use Docker, you can also run everything
-[manually](https://github.com/18F/cms-hitech-apd/wiki/Development-Environment#manually).
+[manually](https://github.com/CMSgov/eAPD/wiki/Development-Environment#manually).
 
 From your command line, switch to the directory where you put the code and
 then run `docker-compose up`. This step could take a few minutes. Once it's
@@ -68,13 +68,13 @@ a filled-in APD. There is also an admin account with username `admin` and
 password `password`.
 
 See the
-[testing documentation](https://github.com/18F/cms-hitech-apd/wiki/Development-accessibility%2C-testing%2C-and-linting#testing)
+[testing documentation](https://github.com/CMSgov/eAPD/wiki/Development-accessibility%2C-testing%2C-and-linting#testing)
 for information about running tests.
 
 ### More technical documentation
 
 Check out the
-[developer documentation](https://github.com/18F/cms-hitech-apd/wiki/Development-index)
+[developer documentation](https://github.com/CMSgov/eAPD/wiki/Development-index)
 for a deeper dive into how the app works.
 
 ## Contributing

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/18F/cms-hitech-apd.git"
+    "url": "git+https://github.com/CMSgov/eAPD.git"
   },
   "keywords": [
     "cms",

--- a/api/routes/users/put.endpoint.js
+++ b/api/routes/users/put.endpoint.js
@@ -70,7 +70,7 @@ describe('users endpoint | PUT /users/:userID', () => {
 
       // This makes sure the duplicate-email check doesn't flag accounts that
       // are keeping their email address the same.
-      // https://github.com/18F/cms-hitech-apd/issues/1973
+      // https://github.com/CMSgov/eAPD/issues/1973
       it('...with new content but same email address', async () => {
         const { password: oldPasswordHash } = await db('users')
           .where({ id: 2001 })

--- a/bin/preview-deploy/aws.cleanup.sh
+++ b/bin/preview-deploy/aws.cleanup.sh
@@ -54,7 +54,7 @@ function findExistingInstances() {
 # Gets a list of open pull requests
 function getOpenPullRequests() {
   curl -s \
-    https://api.github.com/repos/18f/cms-hitech-apd/pulls\?state\=open \
+    https://api.github.com/repos/CMSgov/eAPD/pulls\?state\=open \
     | jq -rc ".[].number"
 }
 
@@ -97,14 +97,14 @@ function terminateIfClosedPR() {
 #
 # $1 - pull request number
 function updateGithubComment() {
-  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_TOKEN" https://api.github.com/repos/18f/cms-hitech-apd/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
+  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_TOKEN" https://api.github.com/repos/CMSgov/eAPD/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
     curl -s \
       -H "Authorization: token $GH_BOT_TOKEN" \
       -H "Content-Type: application/json" \
       -d '{"body":"This deploy was cleaned up."}' \
-      -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+      -X PATCH "https://api.github.com/repos/CMSgov/eAPD/issues/comments/$ID"
   fi
 }
 

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -123,17 +123,19 @@ nvm alias default 10
 npm i -g pm2
 
 # Clone from Github
-git clone --single-branch -b __GIT_BRANCH__ https://github.com/18F/cms-hitech-apd.git
+git clone --single-branch -b __GIT_BRANCH__ https://github.com/CMSgov/eAPD.git
 
 # Build the web app and move it into place
-cd cms-hitech-apd/web
+#cd cms-hitech-apd/web
+cd eAPD/web
 npm ci
 API_URL=/api/ npm run build
 mv dist/* /app/web
 cd ~
 
 # Move the API code into place, then go set it up
-mv cms-hitech-apd/api/* /app/api
+#mv cms-hitech-apd/api/* /app/api
+mv eAPD/api/* /app/api
 cd /app/api
 
 npm ci --only=production

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -126,7 +126,6 @@ npm i -g pm2
 git clone --single-branch -b __GIT_BRANCH__ https://github.com/CMSgov/eAPD.git
 
 # Build the web app and move it into place
-#cd cms-hitech-apd/web
 cd eAPD/web
 npm ci
 API_URL=/api/ npm run build
@@ -134,7 +133,6 @@ mv dist/* /app/web
 cd ~
 
 # Move the API code into place, then go set it up
-#mv cms-hitech-apd/api/* /app/api
 mv eAPD/api/* /app/api
 cd /app/api
 

--- a/bin/preview-deploy/github-comment.sh
+++ b/bin/preview-deploy/github-comment.sh
@@ -14,7 +14,7 @@ function postOrUpdateComment() {
   local GIT_SHA=$3
 
   # Update the comment on Github, if there's one already.  This way we'll know the bot updated the thing.
-  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_TOKEN" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
+  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_TOKEN" https://api.github.com/repos/CMSgov/eAPD/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
     # Use $ before the body to use ANSI encoding, which preserves the newlines.
@@ -23,14 +23,14 @@ function postOrUpdateComment() {
       -H "Authorization: token $GH_BOT_TOKEN" \
       -H "Content-Type: application/json" \
       -d $'{"body":"See this pull request in action: '"$PREVIEW_URL"'\n\n'"$GIT_SHA"'"}' \
-      -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+      -X PATCH "https://api.github.com/repos/CMSgov/eAPD/issues/comments/$ID"
   else
     # Post a new message if one doesn't already exist.
     curl -s \
       -H "Authorization: token $GH_BOT_TOKEN" \
       -H "Content-Type: application/json" \
       -d '{"body":"See this pull request in action: '"$PREVIEW_URL"'"}' \
-      -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
+      -X POST "https://api.github.com/repos/CMSgov/eAPD/issues/$PRNUM/comments"
   fi
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/18F/cms-hitech-apd.git"
+    "url": "git+https://github.com/CMSgov/eAPD.git"
   },
   "keywords": [
     "cms",
@@ -53,9 +53,9 @@
   ],
   "license": "CC0-1.0",
   "bugs": {
-    "url": "https://github.com/18F/cms-hitech-apd/issues"
+    "url": "https://github.com/CMSgov/eAPD/issues"
   },
-  "homepage": "https://github.com/18F/cms-hitech-apd#readme",
+  "homepage": "https://github.com/CMSgov/eAPD#readme",
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
     "@cmsgov/design-system-core": "^3.7.0",

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -273,7 +273,7 @@ describe('budget reducer', () => {
             {
               // This activity is to represent the case where an activity's
               // total costs are zero, because that was causing budget math
-              // errors. https://github.com/18F/cms-hitech-apd/issues/1740
+              // errors. https://github.com/CMSgov/eAPD/issues/1740
               id: 5,
               key: '5',
               name: 'zero total',
@@ -322,7 +322,7 @@ describe('budget reducer', () => {
               // This activity is to represent the case where an activity
               // does not have a funding program yet. New activities do not
               // get a funding program by default.
-              // https://github.com/18F/cms-hitech-apd/issues/2059
+              // https://github.com/CMSgov/eAPD/issues/2059
               id: 6,
               key: '6',
               name: 'no funding program',


### PR DESCRIPTION
This PR is to update the hardcode repo URLs and references from the 18F repo to the CMSgov repo.

### This pull request changes...

- Changed Hardcoded URLs in scripts
- Changed other URLs that referenced issues, etc... 

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
