### PR TITLE
Initial IaC

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+module "instance" {
+    source = "./modules/instances"
+
+    eapd_jumpbox_ami = var.eapd_jumpbox_ami
+    eapd_jumpbox_instance_type = var.eapd_jumpbox_instance_type
+    eapd_jumpbox_key_name = var.eapd_jumpbox_key_name
+    eapd_jumpbox_vpc_security_group_ids = var.eapd_jumpbox_vpc_security_group_ids
+    eapd_jumpbox_subnet_id = var.eapd_jumpbox_subnet_id
+    eapd_jumpbox_associate_public_ip_address = var.eapd_jumpbox_associate_public_ip_address
+}

--- a/terraform/modules/instances/eapd_jumpbox.tf
+++ b/terraform/modules/instances/eapd_jumpbox.tf
@@ -1,11 +1,4 @@
-/*
-variable "eapd_jumpbox_ami" {}
-variable "eapd_jumpbox_instance_type" {}
-variable "eapd_jumpbox_key_name" {}
-variable "eapd_jumpbox_vpc_security_group_ids" {}
-variable "eapd_jumpbox_subnet_id" {}
-variable "eapd_jumpbox_associate_public_ip_address" {}
-*/
+
 
 resource "aws_instance" "eapd_jumpbox" {
     ami = var.eapd_jumpbox_ami

--- a/terraform/modules/instances/eapd_jumpbox.tf
+++ b/terraform/modules/instances/eapd_jumpbox.tf
@@ -1,0 +1,20 @@
+/*
+variable "eapd_jumpbox_ami" {}
+variable "eapd_jumpbox_instance_type" {}
+variable "eapd_jumpbox_key_name" {}
+variable "eapd_jumpbox_vpc_security_group_ids" {}
+variable "eapd_jumpbox_subnet_id" {}
+variable "eapd_jumpbox_associate_public_ip_address" {}
+*/
+
+resource "aws_instance" "eapd_jumpbox" {
+    ami = var.eapd_jumpbox_ami
+    instance_type = var.eapd_jumpbox_instance_type
+    key_name = var.eapd_jumpbox_key_name
+    vpc_security_group_ids = var.eapd_jumpbox_vpc_security_group_ids
+    subnet_id = var.eapd_jumpbox_subnet_id
+    associate_public_ip_address = var.eapd_jumpbox_associate_public_ip_address
+    tags = {
+        Name = "eAPD Jumpbox"
+    }
+}

--- a/terraform/modules/instances/variables.tf
+++ b/terraform/modules/instances/variables.tf
@@ -1,13 +1,3 @@
-/*
-variable "eapd_jumpbox_ami" {}
-variable "eapd_jumpbox_instance_type" {}
-variable "eapd_jumpbox_key_name" {}
-variable "eapd_jumpbox_vpc_security_group_ids" {}
-variable "eapd_jumpbox_subnet_id" {}
-variable "eapd_jumpbox_associate_public_ip_address" {}
-*/
-//variable "eapd_jumpbox_tags_name" {}
-//variable "eapd_jumpbox_tags_provisioner" {}
 
 variable "eapd_jumpbox_ami" {}
 variable "eapd_jumpbox_instance_type" {}

--- a/terraform/modules/instances/variables.tf
+++ b/terraform/modules/instances/variables.tf
@@ -1,0 +1,17 @@
+/*
+variable "eapd_jumpbox_ami" {}
+variable "eapd_jumpbox_instance_type" {}
+variable "eapd_jumpbox_key_name" {}
+variable "eapd_jumpbox_vpc_security_group_ids" {}
+variable "eapd_jumpbox_subnet_id" {}
+variable "eapd_jumpbox_associate_public_ip_address" {}
+*/
+//variable "eapd_jumpbox_tags_name" {}
+//variable "eapd_jumpbox_tags_provisioner" {}
+
+variable "eapd_jumpbox_ami" {}
+variable "eapd_jumpbox_instance_type" {}
+variable "eapd_jumpbox_key_name" {}
+variable "eapd_jumpbox_vpc_security_group_ids" {}
+variable "eapd_jumpbox_subnet_id" {}
+variable "eapd_jumpbox_associate_public_ip_address" {}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+    region = var.eapd_region
+    profile = ""
+    access_key = ""
+    secret_key = ""
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,8 @@
+variable "eapd_region" {}
+
+variable "eapd_jumpbox_ami" {}
+variable "eapd_jumpbox_instance_type" {}
+variable "eapd_jumpbox_key_name" {}
+variable "eapd_jumpbox_vpc_security_group_ids" {}
+variable "eapd_jumpbox_subnet_id" {}
+variable "eapd_jumpbox_associate_public_ip_address" {}


### PR DESCRIPTION
This PR adds the initial IaC base to our GitHub repo. It is not currently a part of our CircleCI workflow and needs to be run manually. I am writing up the documentation on how to run this code currently.

### This pull request changes...

- Nothing impacting the current code
- Running the terraform in will create/destroy the eAPD Jumpbox instance.

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
