### PR TITLE
Match private contractor costs section on export view to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,19 @@
 # Next release
 
-Anticipated release: August 10, 2020
+Anticipated release: September 21st, 2020
 
 #### 🚀 New features
 
-- Upgrade to @cmsgov/design-system v2.0.0, remove focus styles ([#2412])
-- Update button text to match verbiage on page ([#2367])
-- Update Key Personnel and Program Management page instructions and help text ([#2325])
-- Change "Objectives and key results" Nav Bar title to match contents of page ([#2368])
-- Activity section Previous & Continue buttons/arrow iconography ([#2213])
+- Match private contractor costs section on export view to builder ([#2393])
 
 #### 🐛 Bugs fixed
 
-- Content in the export view needs to match the builder ([#2387])
-- Key personnel FTE not being saved for 2022 ([#2401])
-- Arrows in the side nav should be consistent ([#2188])
-- Nav bar does not indicate correct location with launch of different APD ([#2223])
-- Clicking on the navigation places you right below the anchor point ([#2410])
-- Scroll changes navigation buttons on export and submit page ([#2359])
-- When navigating with Continue/Previous buttons, Nav does not expand to current page ([#2415])
 
 #### ⚙️ Behind the scenes
 
-- Use audit-ci for auditing node packages within our pipeline ([#2335])
 
 # Previous releases
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-[#2387]: https://github.com/CMSgov/eAPD/issues/2387
-[#2412]: https://github.com/CMSgov/eAPD/issues/2412
-[#2335]: https://github.com/CMSgov/eAPD/issues/2335
-[#2367]: https://github.com/CMSgov/eAPD/issues/2367
-[#2325]: https://github.com/CMSgov/eAPD/issues/2325
-[#2401]: https://github.com/CMSgov/eAPD/issues/2401
-[#2188]: https://github.com/CMSgov/eAPD/issues/2188
-[#2223]: https://github.com/CMSgov/eAPD/issues/2223
-[#2410]: https://github.com/CMSgov/eAPD/issues/2410
-[#2359]: https://github.com/CMSgov/eAPD/issues/2359
-[#2415]: https://github.com/CMSgov/eAPD/issues/2415
-[#2368]: https://github.com/CMSgov/eAPD/issues/2368
-[#2213]: https://github.com/cmsgov/eapd/issues/2213
+[#2393]: https://github.com/CMSgov/eAPD/issues/2393

--- a/web/src/containers/viewOnly/activities/Activity.js
+++ b/web/src/containers/viewOnly/activities/Activity.js
@@ -102,18 +102,22 @@ const Activity = ({ activity, activityIndex }) => {
 
     return (
       <Fragment>
-        <p>
+        <p className="ds-u-margin-bottom--0">
           <strong>
             {index + 1}. {contractor.name}
           </strong>
           {contractor.hourly.useHourly === true && ' (hourly resource)'}
         </p>
-        <p>{contractor.description}</p>
-        <p>
-          <strong>Contract term: </strong>
-          {contractTerm()}
-        </p>
+        <p className="ds-u-margin-top--0">{contractor.description}</p>
         <ul className="ds-c-list--bare">
+          <li>
+            <strong>Contract term: </strong>
+            {contractTerm()}
+          </li>
+          <li>
+            <strong>Total Cost: </strong>
+            <Dollars>{contractor.totalCost}</Dollars>
+          </li>
           {Object.entries(contractor.years).map(([year, cost]) => (
             <li key={year}>
               <strong>FFY {year} Cost:</strong> <Dollars>{cost}</Dollars>
@@ -129,10 +133,6 @@ const Activity = ({ activity, activityIndex }) => {
             </li>
           ))}
         </ul>
-        <p>
-          <strong>Total Cost: </strong>
-          <Dollars>{contractor.totalCost}</Dollars>
-        </p>
       </Fragment>
     );
   };


### PR DESCRIPTION
Resolves #2393

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [x] Changelog is updated as appropriate

### This feature is done when...

- [x] Design has approved the experience
- [x] Product has approved the experience
