### PR TITLE
Standards and conditions is in the wrong area on export view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,43 +1,19 @@
 # Next release
 
-Anticipated release: August 10, 2020
+Anticipated release: September 21st, 2020
 
 #### 🚀 New features
 
-- Upgrade to @cmsgov/design-system v2.0.0, remove focus styles ([#2412])
-- Update button text to match verbiage on page ([#2367])
-- Update Key Personnel and Program Management page instructions and help text ([#2325])
-- Change "Objectives and key results" Nav Bar title to match contents of page ([#2368])
-- Activity section Previous & Continue buttons/arrow iconography ([#2213])
+* Standards and conditions is in the wrong area on export view [#2386]
 
 #### 🐛 Bugs fixed
 
-- Content in the export view needs to match the builder ([#2387])
-- Key personnel FTE not being saved for 2022 ([#2401])
-- Arrows in the side nav should be consistent ([#2188])
-- Nav bar does not indicate correct location with launch of different APD ([#2223])
-- Clicking on the navigation places you right below the anchor point ([#2410])
-- Scroll changes navigation buttons on export and submit page ([#2359])
-- When navigating with Continue/Previous buttons, Nav does not expand to current page ([#2415])
 
 #### ⚙️ Behind the scenes
 
-- Use audit-ci for auditing node packages within our pipeline ([#2335])
 
 # Previous releases
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-[#2387]: https://github.com/CMSgov/eAPD/issues/2387
-[#2412]: https://github.com/CMSgov/eAPD/issues/2412
-[#2335]: https://github.com/CMSgov/eAPD/issues/2335
-[#2367]: https://github.com/CMSgov/eAPD/issues/2367
-[#2325]: https://github.com/CMSgov/eAPD/issues/2325
-[#2401]: https://github.com/CMSgov/eAPD/issues/2401
-[#2188]: https://github.com/CMSgov/eAPD/issues/2188
-[#2223]: https://github.com/CMSgov/eAPD/issues/2223
-[#2410]: https://github.com/CMSgov/eAPD/issues/2410
-[#2359]: https://github.com/CMSgov/eAPD/issues/2359
-[#2415]: https://github.com/CMSgov/eAPD/issues/2415
-[#2368]: https://github.com/CMSgov/eAPD/issues/2368
-[#2213]: https://github.com/cmsgov/eapd/issues/2213
+[#2386]: https://github.com/CMSgov/eAPD/issues/2386

--- a/web/src/containers/viewOnly/activities/Activity.js
+++ b/web/src/containers/viewOnly/activities/Activity.js
@@ -172,6 +172,47 @@ const Activity = ({ activity, activityIndex }) => {
         <small>
           Activity {activityIndex + 1} ({activity.name})
         </small>
+        <br /> Standards and Conditions
+      </h3>
+
+      <p>
+        <strong>
+          This activity supports the Medicaid standards and conditions from 42
+          CFR 433.112.
+        </strong>
+      </p>
+      {activity.standardsAndConditions.supports ? (
+        <p
+          dangerouslySetInnerHTML={{
+            __html: activity.standardsAndConditions.supports
+          }}
+        />
+      ) : (
+        <p>
+          No response was provided for how this activity will support the
+          Medicaid standards and conditions.
+        </p>
+      )}
+
+      <p>
+        <strong>
+          This activity does not support the Medicaid standards and conditions
+          from 42 CFR 433.112.
+        </strong>
+      </p>
+      {activity.standardsAndConditions.doesNotSupport ? (
+        <p>{activity.standardsAndConditions.doesNotSupport}</p>
+      ) : (
+        <p>
+          No response was provided for how this activity will support the
+          Medicaid standards and conditions.
+        </p>
+      )}
+
+      <h3 className="viewonly-activity-header">
+        <small>
+          Activity {activityIndex + 1} ({activity.name})
+        </small>
         <br />
         Objectives and Key Results
       </h3>
@@ -246,47 +287,6 @@ const Activity = ({ activity, activityIndex }) => {
         costAllocation={activity.costAllocation}
         isViewOnly
       />
-
-      <h3 className="viewonly-activity-header">
-        <small>
-          Activity {activityIndex + 1} ({activity.name})
-        </small>
-        <br /> Standards and Conditions
-      </h3>
-
-      <p>
-        <strong>
-          This activity supports the Medicaid standards and conditions from 42
-          CFR 433.112.
-        </strong>
-      </p>
-      {activity.standardsAndConditions.supports ? (
-        <p
-          dangerouslySetInnerHTML={{
-            __html: activity.standardsAndConditions.supports
-          }}
-        />
-      ) : (
-        <p>
-          No response was provided for how this activity will support the
-          Medicaid standards and conditions.
-        </p>
-      )}
-
-      <p>
-        <strong>
-          This activity does not support the Medicaid standards and conditions
-          from 42 CFR 433.112.
-        </strong>
-      </p>
-      {activity.standardsAndConditions.doesNotSupport ? (
-        <p>{activity.standardsAndConditions.doesNotSupport}</p>
-      ) : (
-        <p>
-          No response was provided for how this activity will support the
-          Medicaid standards and conditions.
-        </p>
-      )}
     </Fragment>
   );
 };


### PR DESCRIPTION
Resolves #2386

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [x] Changelog is updated as appropriate

### This feature is done when...

- [x] Design has approved the experience
- [x] Product has approved the experience
