### PR TITLE
Replace the “Cost Allocation and Budget for FFY 2020” table with part of the new "Summary Budget by Activity” table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,17 @@
 # Next release
 
-Anticipated release: October 16th, 2020
+Anticipated release: October 26th, 2020
 
 #### 🚀 New features
 
-- Updates tables to increase accessibility ([#2501])
-- Change order of fields and field/title names on Cost Allocation and Other Funding + Budget and FFP pages. ([#2322])
-- Add bulleted lists, numbered lists, formatting dropdown to the RichText editor ([#2521])
-- Updated inputs in the Estimated Quarterly Incentive Payments table to use aria-labelledby for better UX/a11y ([#2503])
-- Updates markup to use semantic `<nav>` and `<main>` where appropriate ([#2502])
-- Change order of fields and field/title names on Cost Allocation and Other Funding + Budget and FFP pages. ([#2322])
-- Other funding amount should be represented as a subtraction on Activity Breakdown table ([#2429])
+- Replace the “Cost Allocation and Budget for FFY 2020” table with part of the new "Summary Budget by Activity” table ([#2306])
 
 #### 🐛 Bugs fixed
 
-
 #### ⚙️ Behind the scenes
-
 
 # Previous releases
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-[#2501]: https://github.com/CMSgov/eAPD/issues/2501
-[#2322]: https://github.com/CMSgov/eAPD/issues/2322
-[#2521]: https://github.com/CMSgov/eAPD/issues/2521
-[#2503]: https://github.com/CMSgov/eAPD/issues/2503
-[#2502]: https://github.com/CMSgov/eAPD/issues/2502
-[#2322]: https://github.com/CMSgov/eAPD/issues/2322
-[#2429]: https://github.com/CMSgov/eAPD/issues/2429
+[#2306]: https://github.com/CMSgov/eAPD/issues/2306

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -11,7 +11,8 @@ import Dollars from '../../components/Dollars';
 import {
   selectCostAllocationForActivityByIndex,
   selectActivityCostSummary,
-  selectActivityByIndex
+  selectActivityByIndex,
+  selectActivityTotalForBudgetByActivityIndex
 } from '../../reducers/activities.selectors';
 import { getUserStateOrTerritory } from '../../reducers/user.selector';
 import CostAllocationRows, { CostSummaryRows } from './CostAllocationRows';
@@ -96,6 +97,7 @@ const CostAllocateFFP = ({
   activityName,
   costAllocation,
   costSummary,
+  otherFunding,
   aKey,
   isViewOnly,
   setFundingSplit,
@@ -122,7 +124,12 @@ const CostAllocateFFP = ({
             id={`activity${activityIndex}-ffy${ffy}`}
           >
             <tbody>
-              <CostAllocationRows years={years} ffy={ffy} />
+              <CostAllocationRows
+                years={years}
+                ffy={ffy}
+                activityIndex={activityIndex}
+                otherFunding={otherFunding}
+              />
 
               {/* in viewonly mode, we'll pull everything into a single table
                   table since there aren't form elements to fill in */}
@@ -279,6 +286,7 @@ CostAllocateFFP.propTypes = {
   activityName: PropTypes.string.isRequired,
   costAllocation: PropTypes.object.isRequired,
   costSummary: PropTypes.object.isRequired,
+  otherFunding: PropTypes.object.isRequired,
   isViewOnly: PropTypes.bool,
   setFundingSplit: PropTypes.func.isRequired,
   stateName: PropTypes.string.isRequired
@@ -295,17 +303,20 @@ const mapStateToProps = (
     getActivity = selectActivityByIndex,
     getCostAllocation = selectCostAllocationForActivityByIndex,
     getCostSummary = selectActivityCostSummary,
-    getState = getUserStateOrTerritory
+    getState = getUserStateOrTerritory,
+    getActivityTotal = selectActivityTotalForBudgetByActivityIndex
   } = {}
 ) => {
   const activity = getActivity(state, { activityIndex });
+  const activityTotal = getActivityTotal(state, { activityIndex });
 
   return {
     aKey: activity.key,
     activityName: activity.name || `Activity ${activityIndex + 1}`,
     costAllocation: getCostAllocation(state, { activityIndex }),
     costSummary: getCostSummary(state, { activityIndex }),
-    stateName: getState(state).name
+    stateName: getState(state).name,
+    otherFunding: activityTotal.data.otherFunding
   };
 };
 

--- a/web/src/containers/activity/CostAllocateFFP.test.js
+++ b/web/src/containers/activity/CostAllocateFFP.test.js
@@ -6,9 +6,7 @@ import {
   mapStateToProps,
   mapDispatchToProps
 } from './CostAllocateFFP';
-import {
-  setCostAllocationFFPFundingSplit
-} from '../../actions/editActivity';
+import { setCostAllocationFFPFundingSplit } from '../../actions/editActivity';
 
 describe('the CostAllocateFFP component', () => {
   const props = {
@@ -206,17 +204,37 @@ describe('the CostAllocateFFP component', () => {
     const getState = jest.fn();
     getState.mockReturnValue({ name: 'denial' });
 
+    const getActivityTotal = jest.fn();
+    getActivityTotal.mockReturnValue({
+      data: {
+        otherFunding: {
+          2020: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 },
+          2021: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+        }
+      }
+    });
+
     expect(
       mapStateToProps(
         'my state object',
         { activityIndex: 0 },
-        { getActivity, getCostAllocation, getCostSummary, getState }
+        {
+          getActivity,
+          getCostAllocation,
+          getCostSummary,
+          getState,
+          getActivityTotal
+        }
       )
     ).toEqual({
       aKey: 'activity key',
       activityName: 'activity name',
       costAllocation: 'cost allocation',
       costSummary: 'cost summary',
+      otherFunding: {
+        2020: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 },
+        2021: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+      },
       stateName: 'denial'
     });
 
@@ -238,13 +256,23 @@ describe('the CostAllocateFFP component', () => {
       mapStateToProps(
         'my state object',
         { activityIndex: 0 },
-        { getActivity, getCostAllocation, getCostSummary, getState }
+        {
+          getActivity,
+          getCostAllocation,
+          getCostSummary,
+          getState,
+          getActivityTotal
+        }
       )
     ).toEqual({
       aKey: 'activity key',
       activityName: 'Activity 1',
       costAllocation: 'cost allocation',
       costSummary: 'cost summary',
+      otherFunding: {
+        2020: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 },
+        2021: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+      },
       stateName: 'denial'
     });
   });

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
@@ -21,7 +21,7 @@ exports[`the CostAllocateFFP component renders correctly renders correctly in ed
   >
     <tbody>
       <CostAllocationRows
-        activityIndex={-1}
+        activityIndex={0}
         ffy="1990"
         otherFunding={null}
         years={
@@ -300,7 +300,7 @@ exports[`the CostAllocateFFP component renders correctly renders correctly in ed
   >
     <tbody>
       <CostAllocationRows
-        activityIndex={-1}
+        activityIndex={0}
         ffy="1991"
         otherFunding={null}
         years={
@@ -733,7 +733,7 @@ exports[`the CostAllocateFFP component renders correctly renders correctly in vi
   >
     <tbody>
       <CostAllocationRows
-        activityIndex={-1}
+        activityIndex={0}
         ffy="1990"
         otherFunding={null}
         years={
@@ -931,7 +931,7 @@ exports[`the CostAllocateFFP component renders correctly renders correctly in vi
   >
     <tbody>
       <CostAllocationRows
-        activityIndex={-1}
+        activityIndex={0}
         ffy="1991"
         otherFunding={null}
         years={

--- a/web/src/reducers/activities.selectors.js
+++ b/web/src/reducers/activities.selectors.js
@@ -261,3 +261,8 @@ export const selectGoalsByActivityIndex = (state, { activityIndex }) => {
   }
   return null;
 };
+
+export const selectActivityTotalForBudgetByActivityIndex = (
+  { budget },
+  { activityIndex }
+) => budget.activityTotals[activityIndex] || null;

--- a/web/src/reducers/activities.selectors.test.js
+++ b/web/src/reducers/activities.selectors.test.js
@@ -11,6 +11,7 @@ import {
   selectActivitiesSidebar,
   selectOKRsByActivityIndex,
   selectGoalsByActivityIndex,
+  selectActivityTotalForBudgetByActivityIndex,
   makeSelectCostAllocateFFPBudget,
   selectActivityCount
 } from './activities.selectors';
@@ -566,6 +567,42 @@ describe('activities state selectors', () => {
               data: {
                 activities: []
               }
+            }
+          },
+          { activityIndex: 1 }
+        )
+      ).toEqual(null);
+    });
+  });
+
+  describe('selects activity total by index', () => {
+    it('returns goals if the activity exists', () => {
+      expect(
+        selectActivityTotalForBudgetByActivityIndex(
+          {
+            budget: {
+              activityTotals: [
+                {
+                  data: {
+                    otherFunding: { 2020: { total: 0 }, 2021: { total: 0 } }
+                  }
+                }
+              ]
+            }
+          },
+          { activityIndex: 0 }
+        )
+      ).toEqual({
+        data: { otherFunding: { 2020: { total: 0 }, 2021: { total: 0 } } }
+      });
+    });
+
+    it('returns null if the activity does not exist', () => {
+      expect(
+        selectActivityTotalForBudgetByActivityIndex(
+          {
+            budget: {
+              activityTotals: []
             }
           },
           { activityIndex: 1 }


### PR DESCRIPTION
Added other funding amount to the Activity {X} Budget for FFY {XX} so that it matches the Summary Budget by Activity

resolves #2306 

### This pull request changes...

- added other funding amount to the Activity {X} Budget for FFY {XX}

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
~- [ ] The change has been documented~
~- [ ] Associated OpenAPI documentation has been updated~
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
