### PR TITLE
Tbolt/2611 tinymce help plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Anticipated release: October 26th, 2020
 - Rename State Cost Category page and update Nav Bar to better assist users in navigation ([#2432])
 - Update Program Activities headers, labels, and help text ([#2528])
 - Rename Objectives and Key Results to Outcomes and Metrics ([#2584])
+- Enable the TinyMCE Help guide ([#2611])
 
 #### 🐛 Bugs fixed
 
@@ -21,3 +22,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#2432]: https://github.com/CMSgov/eAPD/issues/2432
 [#2528]: https://github.com/CMSgov/eAPD/issues/2528
 [#2584]: https://github.com/CMSgov/eAPD/issues/2584
+[#2611]: https://github.com/CMSgov/eAPD/issues/2611

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,3 @@
 {
-  "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "detect-browser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-4.8.0.tgz",
-      "integrity": "sha512-f4h2dFgzHUIpjpBLjhnDIteXv8VQiUm8XzAuzQtYUqECX/eKh67ykuiVoyb7Db7a0PUSmJa3OGXStG0CbQFUVw=="
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/web/src/components/RichText.js
+++ b/web/src/components/RichText.js
@@ -13,6 +13,7 @@ import 'tinymce/plugins/autoresize';
 import 'tinymce/plugins/lists';
 import 'tinymce/plugins/paste';
 import 'tinymce/plugins/spellchecker';
+import 'tinymce/plugins/help';
 
 import { uploadFile } from '../actions/editApd';
 import { generateKey } from '../util';
@@ -95,7 +96,8 @@ class RichText extends Component {
       'autoresize',
       'lists',
       'paste',
-      'spellchecker'
+      'spellchecker',
+      'help'
     ];
 
     // https://www.tiny.cloud/docs/advanced/available-toolbar-buttons/
@@ -107,7 +109,8 @@ class RichText extends Component {
       "outdent indent",
       "numlist bullist",
       "formatselect",
-      "eapdImageUpload"
+      "eapdImageUpload",
+      "help"
     ].join(" | ");
 
     return (

--- a/web/src/components/__snapshots__/RichText.test.js.snap
+++ b/web/src/components/__snapshots__/RichText.test.js.snap
@@ -20,9 +20,10 @@ exports[`RichText component renders as expected 1`] = `
           "lists",
           "paste",
           "spellchecker",
+          "help",
         ],
         "setup": [Function],
-        "toolbar": "undo redo | style | bold italic strikethrough forecolor | alignleft aligncenter alignright alignjustify | outdent indent | numlist bullist | formatselect | eapdImageUpload",
+        "toolbar": "undo redo | style | bold italic strikethrough forecolor | alignleft aligncenter alignright alignjustify | outdent indent | numlist bullist | formatselect | eapdImageUpload | help",
       }
     }
     onEditorChange={[Function]}

--- a/web/src/util/browser.js
+++ b/web/src/util/browser.js
@@ -14,7 +14,7 @@ const browserIsGreen =
   // Most recent Firefox extended support release as of April 2020.
   (browser.name === 'firefox' && browser.version >= 68) ||
   // First Chromium build of Edge. No longer support pre-Chromium builds.
-  (browser.name === 'edge-chromium');
+  (browser.name === 'edge' && browser.version >= 79);
 
 // Yellow support is for browsers we think should support all the basic
 // functionality of the app, though more advanced features and some visual

--- a/web/src/util/browser.js
+++ b/web/src/util/browser.js
@@ -14,7 +14,7 @@ const browserIsGreen =
   // Most recent Firefox extended support release as of April 2020.
   (browser.name === 'firefox' && browser.version >= 68) ||
   // First Chromium build of Edge. No longer support pre-Chromium builds.
-  (browser.name === 'edge' && browser.version >= 79);
+  (browser.name === 'edge-chromium');
 
 // Yellow support is for browsers we think should support all the basic
 // functionality of the app, though more advanced features and some visual


### PR DESCRIPTION
Resolves #2611 

### This pull request changes...

- Enables TinyMCE Help Guide. To test: Navigate into a rich text area in an APD. Press `Alt + 0`. This should open a overlay with the tinymce help guide. Note: on MacOS the shortcut is `option + 0`

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
