### PR TITLE
Staging is different than preview and requires additional changes

### DIFF
--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -9,7 +9,12 @@ chown -R :eapd /app
 chmod g+w /app
 
 # Oddly, EC2 images don't have git installed. Shruggy person.
-yum -y install git amazon-cloudwatch-agent
+yum -y install git
+
+#Install CloudWatch Agent
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/arm64/latest/amazon-cloudwatch-agent.rpm
+
+rpm -U ./amazon-cloudwatch-agent.rpm
 
 # Configure CloudWatch Agent
 cat <<CWAGENTCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/cwagent.json


### PR DESCRIPTION
Added different installation method for staging/prod since it is different than preview

### This pull request changes...

- Installation method of the CloudWatch Agent

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
