### PR TITLE
Changing delimiter of sed command from / to | to match all of the oth…

### DIFF
--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -87,7 +87,7 @@ function configureUserData() {
   # names can contain slashes
   sed -i'.backup' -e "s|__GIT_BRANCH__|\"`echo $BRANCH`\"|g" aws.user-data.sh
 
-  sed -i'.backup' -e "s/__PBKDF2_ITERATIONS__/`echo $API_PBKDF2_ITERATIONS`/g" aws.user-data.sh
+  sed -i'.backup' -e "s|__PBKDF2_ITERATIONS__|`echo $API_PBKDF2_ITERATIONS`|g" aws.user-data.sh
 
   sed -i'.backup' -e "s|__OKTA_DOMAIN__|`echo $OKTA_DOMAIN`|g" aws.user-data.sh
 


### PR DESCRIPTION
Changing delimiter of sed command from / to | to match all of the other sed commands

### This pull request changes...

- One sed command has its delimiter changed from / to | to match all the other sed commands.

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
