### PR TITLE
updated affiliation endpoint to take in status and filter returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Anticipated release: November 30, 2020
 - Create endpoints for requesting/approving access ([#2574])
 - Show the Activity Total Cost in the Proposed Budget Summary and Budget and FFP page ([#2597])
 - Update authorization to use new affiliations table ([#2617])
+- Update endpoint for affiliations to filter by status ([#2682])
 
 #### 🐛 Bugs fixed
 
@@ -43,3 +44,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#2617]: https://github.com/cmsgov/eapd/issues/2617
 [#2679]: https://github.com/CMSgov/eAPD/issues/2679
 [#2655]: https://github.com/CMSgov/eAPD/issues/2655
+[#2682]: https://github.com/CMSgov/eAPD/issues/2682

--- a/api/auth/mockedOktaAuth.js
+++ b/api/auth/mockedOktaAuth.js
@@ -60,49 +60,6 @@ const mockOktaClient = {
   }
 };
 
-const getGroups = userId => {
-  if (
-    userId === 'all-permissions-no-state' ||
-    userId === 'all-permissions-and-state'
-  ) {
-    return ['eAPD Admin', 'eAPD State Coordinator'];
-  }
-  return [];
-};
-
-const getAffiliations = userId => {
-  if (userId === 'all-permissions-and-state') {
-    return ['MN'];
-  }
-  return [];
-};
-
-const mockCallOktaEndpoint = async endpoint => {
-  if (endpoint) {
-    if (endpoint.test(/\/api\/v1\/users\/[a-zA-Z0-9]+\/groups/)) {
-      const urlPaths = endpoint.split('/');
-      const userId = urlPaths[3];
-      const groups = getGroups(userId);
-      return new Promise(resolve => {
-        resolve(groups);
-      });
-    }
-    if (endpoint.test(/\/api\/v1\/apps\/[a-zA-Z0-9]+\/users\/[a-zA-Z0-9]+/)) {
-      const urlPaths = endpoint.split('/');
-      const userId = urlPaths[5];
-      const affiliations = getAffiliations(userId);
-      return new Promise(resolve => {
-        resolve({
-          affiliations
-        });
-      });
-    }
-  }
-  return new Promise(resolve => {
-    resolve();
-  });
-};
-
 const mockVerifyJWT = token => {
   if (token === 'no-permissions') {
     return new Promise(resolve => {
@@ -153,7 +110,6 @@ const mockVerifyJWT = token => {
 };
 
 module.exports = {
-  mockCallOktaEndpoint,
   mockOktaClient,
   mockVerifyJWT
 };

--- a/api/db/affiliations.js
+++ b/api/db/affiliations.js
@@ -1,0 +1,108 @@
+const logger = require('../logger')('db/affiliations');
+const { oktaClient } = require('../auth/oktaAuth');
+const knex = require('./knex');
+
+const selectedColumns = [
+  'auth_affiliations.id',
+  'auth_affiliations.user_id as userId',
+  'auth_affiliations.state_id as stateId',
+  'auth_affiliations.status',
+  'auth_affiliations.created_at as createdAt',
+  'auth_affiliations.updated_at as updatedAt',
+  'auth_affiliations.updated_by as updatedById',
+  'auth_roles.name as role'
+];
+
+const getAffiliationsByStateId = ({ stateId, status }) => {
+  if (status === 'pending') {
+    return knex('auth_affiliations')
+      .select(selectedColumns)
+      .leftJoin('auth_roles', 'auth_affiliations.role_id', 'auth_roles.id')
+      .where({
+        state_id: stateId,
+        status: 'requested'
+      });
+  }
+  if (status === 'active') {
+    return knex('auth_affiliations')
+      .select(selectedColumns)
+      .leftJoin('auth_roles', 'auth_affiliations.role_id', 'auth_roles.id')
+      .where({
+        state_id: stateId,
+        status: 'approved'
+      });
+  }
+  if (status === 'inactive') {
+    return knex('auth_affiliations')
+      .select(selectedColumns)
+      .leftJoin('auth_roles', 'auth_affiliations.role_id', 'auth_roles.id')
+      .whereIn(
+        ['state_id', 'status'],
+        [
+          [stateId, 'denied'],
+          [stateId, 'revoked']
+        ]
+      );
+  }
+  if (status) logger.error(`invalid status ${status}`);
+  return knex('auth_affiliations')
+    .select(selectedColumns)
+    .leftJoin('auth_roles', 'auth_affiliations.role_id', 'auth_roles.id')
+    .where({ state_id: stateId });
+};
+
+const populateAffiliation = async affiliation => {
+  const { userId, updatedById } = affiliation;
+  if (userId) {
+    const {
+      profile: { displayName, email, secondEmail, primaryPhone, mobilePhone }
+    } = await oktaClient.getUser(userId);
+    const { profile: { displayName: updatedByName = null } = {} } = updatedById
+      ? await oktaClient.getUser(updatedById)
+      : {};
+    return {
+      ...affiliation,
+      updatedBy: updatedByName,
+      displayName,
+      email,
+      secondEmail,
+      primaryPhone,
+      mobilePhone
+    };
+  }
+  return null;
+};
+
+const getPopulatedAffiliationsByStateId = async ({ stateId, status }) => {
+  const affiliations = await getAffiliationsByStateId({ stateId, status });
+  if (!affiliations) return [];
+  return Promise.all(
+    affiliations.map(async affiliation => {
+      return populateAffiliation(affiliation);
+    })
+  );
+};
+
+const getAffiliationById = ({ stateId, affiliationId }) => {
+  return knex('auth_affiliations')
+    .select(selectedColumns)
+    .leftJoin('auth_roles', 'auth_affiliations.role_id', 'auth_roles.id')
+    .where({
+      'auth_affiliations.state_id': stateId,
+      'auth_affiliations.id': affiliationId
+    })
+    .first();
+};
+
+const getPopulatedAffiliationById = async ({ stateId, affiliationId }) => {
+  const affiliation = await getAffiliationById({ stateId, affiliationId });
+  if (!affiliation) return null;
+  return populateAffiliation(affiliation);
+};
+
+module.exports = {
+  getAffiliationsByStateId,
+  getPopulatedAffiliationsByStateId,
+  getAffiliationById,
+  getPopulatedAffiliationById
+};

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -1,13 +1,15 @@
+const knex = require('./knex');
+const affiliations = require('./affiliations');
 const apds = require('./apds');
 const auth = require('./auth');
 const files = require('./files');
 const events = require('./events');
-const knex = require('./knex');
 const states = require('./states');
 const users = require('./users');
 
 module.exports = {
   raw: knex,
+  ...affiliations,
   ...auth,
   ...apds,
   ...files,

--- a/api/routes/affiliations/get.endpoint.js
+++ b/api/routes/affiliations/get.endpoint.js
@@ -5,6 +5,9 @@ const {
   unauthorizedTest
 } = require('../../endpoint-tests/utils');
 
+// using state AK because it's the first in the affiliations
+// list so it will be the first affiliation loaded into the
+// user, change once user is set
 describe('Affiliations endpoint | GET', () => {
   const api = login('all-permissions');
   const db = getDB();
@@ -12,27 +15,27 @@ describe('Affiliations endpoint | GET', () => {
   afterAll(() => db.destroy());
 
   describe('GET /states/:stateId/affiliations', () => {
-    unauthenticatedTest('get', '/states/fl/affiliations');
-    unauthorizedTest('get', '/states/fl/affiliations');
+    unauthenticatedTest('get', '/states/ak/affiliations');
+    unauthorizedTest('get', '/states/ak/affiliations');
 
     it('returns 200', async () => {
-      const response = await api.get('/states/fl/affiliations');
+      const response = await api.get('/states/ak/affiliations');
       expect(response.status).toEqual(200);
     });
   });
 
   describe('GET /states/:stateId/affiliations/:id', () => {
-    unauthenticatedTest('get', '/states/fl/affiliations/4000');
-    unauthorizedTest('get', '/states/fl/affiliations/4000');
+    unauthenticatedTest('get', '/states/ak/affiliations/4000');
+    unauthorizedTest('get', '/states/ak/affiliations/4000');
 
     it('returns 200', async () => {
-      const response = await api.get('/states/fl/affiliations/4000');
+      const response = await api.get('/states/ak/affiliations/4000');
       expect(response.status).toEqual(200);
     });
 
     it('returns 400', async () => {
-      const response = await api.get('/states/fl/affiliations/NaN');
+      const response = await api.get('/states/ak/affiliations/9000');
       expect(response.status).toEqual(400);
     });
-  })
+  });
 });

--- a/api/routes/affiliations/get.js
+++ b/api/routes/affiliations/get.js
@@ -1,21 +1,79 @@
-const { raw: knex } = require('../../db');
+const logger = require('../../logger')('affiliations route get');
+const {
+  getPopulatedAffiliationsByStateId: gas,
+  getPopulatedAffiliationById: ga
+} = require('../../db');
 const { can } = require('../../middleware');
 
-module.exports = (app) => {
-  app.get('/states/:stateId/affiliations', can('view-affiliations'), (request, response) => {
-    const { stateId } = request.params;
-    knex('auth_affiliations')
-      .where({ state_id: stateId })
-      .then(rows => response.status(200).json(rows))
-      .catch(() => response.status(400).end());
-  });
+module.exports = (
+  app,
+  {
+    getPopulatedAffiliationsByStateId = gas,
+    getPopulatedAffiliationById = ga
+  } = {}
+) => {
+  app.get(
+    '/states/:stateId/affiliations',
+    can('view-affiliations'),
+    async (request, response, next) => {
+      logger.info({
+        id: request.id,
+        message: `handling GET /states/${request.params.stateId}/affiliations`
+      });
+      const { stateId } = request.params;
+      const { status = null } = request.query;
 
-  app.get('/states/:stateId/affiliations/:id', can('view-affiliations'), (request, response) => {
-    const { stateId, id } = request.params;
-    knex('auth_affiliations')
-      .where({ state_id: stateId, id })
-      .first()
-      .then(row => response.status(200).json(row))
-      .catch(() => response.status(400).end());
-  });
+      try {
+        if (stateId !== request.user.state.id) {
+          logger.verbose('user does not have access to state');
+          return response.status(401).end();
+        }
+
+        const affiliations = await getPopulatedAffiliationsByStateId({
+          stateId,
+          status
+        });
+
+        return response.send(affiliations);
+      } catch (e) {
+        return next(e);
+      }
+    }
+  );
+
+  app.get(
+    '/states/:stateId/affiliations/:id',
+    can('view-affiliations'),
+    async (request, response, next) => {
+      logger.info({
+        id: request.id,
+        message: `handling GET /states/${request.params.stateId}/affiliations/${request.params.id}`
+      });
+      const { stateId, id } = request.params;
+      console.log('user state', request.user.state.id);
+      try {
+        if (stateId !== request.user.state.id) {
+          logger.verbose('user does not have access to state');
+          return response.status(401).end();
+        }
+
+        const affiliation = await getPopulatedAffiliationById({
+          stateId,
+          affiliationId: id
+        });
+
+        if (affiliation) {
+          return response.send(affiliation);
+        }
+
+        logger.verbose({
+          id: request.id,
+          message: `affiliation ${id} does not exist in ${stateId}`
+        });
+        return response.status(400).end();
+      } catch (e) {
+        return next(e);
+      }
+    }
+  );
 };

--- a/api/routes/affiliations/get.js
+++ b/api/routes/affiliations/get.js
@@ -50,7 +50,6 @@ module.exports = (
         message: `handling GET /states/${request.params.stateId}/affiliations/${request.params.id}`
       });
       const { stateId, id } = request.params;
-      console.log('user state', request.user.state.id);
       try {
         if (stateId !== request.user.state.id) {
           logger.verbose('user does not have access to state');

--- a/api/routes/affiliations/get.test.js
+++ b/api/routes/affiliations/get.test.js
@@ -1,0 +1,251 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const can = require('../../middleware').can;
+const getEndpoint = require('./get');
+
+const mockExpress = require('../../util/mockExpress');
+const mockResponse = require('../../util/mockResponse');
+
+let app;
+let res;
+let next;
+
+tap.test('GET /states/:stateId/affiliations', async endpointTest => {
+  let getPopulatedAffiliationsByStateId;
+
+  endpointTest.beforeEach(done => {
+    app = mockExpress();
+    res = mockResponse();
+    next = sinon.stub();
+    getPopulatedAffiliationsByStateId = sinon.stub();
+    done();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    getEndpoint(app);
+
+    setupTest.ok(
+      app.get.calledWith(
+        '/states/:stateId/affiliations',
+        can('view-affiliations'),
+        sinon.match.func
+      ),
+      'state-specific affiliations GET endpoint is registered'
+    );
+  });
+
+  endpointTest.test('get all affiliations handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      getEndpoint(app, {
+        getPopulatedAffiliationsByStateId
+      });
+      handler = app.get.args.find(
+        args => args[0] === '/states/:stateId/affiliations'
+      )[2];
+      done();
+    });
+
+    handlerTest.test('database error', async invalidTest => {
+      const err = { error: 'err0r' };
+      getPopulatedAffiliationsByStateId.rejects(err);
+
+      await handler(
+        { params: { stateId: 'ar' }, query: {}, user: { state: { id: 'ar' } } },
+        res,
+        next
+      );
+
+      invalidTest.ok(next.called, 'next is called');
+      invalidTest.ok(next.calledWith(err), 'pass error to middleware');
+    });
+
+    handlerTest.test(
+      'sends an unauthorized error code if the user does not have the state',
+      async invalidTest => {
+        await handler(
+          {
+            params: { stateId: 'ar' },
+            query: {},
+            user: { state: { id: 'fl' } }
+          },
+          res
+        );
+
+        invalidTest.ok(res.status.calledWith(401), 'HTTP status set to 401');
+        invalidTest.ok(res.send.notCalled, 'no body is sent');
+        invalidTest.ok(res.end.called, 'response is terminated');
+      }
+    );
+
+    handlerTest.test('sends pending affiliations', async test => {
+      const pending = [
+        {
+          id: 29,
+          userId: '00u4oerp8sl6vtG3y297',
+          stateId: 'ar',
+          status: 'requested',
+          createdAt: '2020-12-02T18:30:54.477Z',
+          updatedAt: '2020-12-02T18:30:54.477Z',
+          updatedById: null,
+          role: null,
+          updatedBy: null,
+          displayName: 'Ty Bolchoz',
+          email: 'tbolchoz@fearless.tech',
+          secondEmail: null,
+          primaryPhone: '4438664337',
+          mobilePhone: null
+        },
+        {
+          id: 28,
+          userId: '00u5jkmqzqkGveBeO297',
+          stateId: 'ar',
+          status: 'requested',
+          createdAt: '2020-12-02T18:30:54.477Z',
+          updatedAt: '2020-12-02T18:30:54.477Z',
+          updatedById: null,
+          role: null,
+          updatedBy: null,
+          displayName: 'MFA User',
+          email: 'tforkner+testmfa@fearless.tech',
+          secondEmail: null,
+          primaryPhone: '5555555555',
+          mobilePhone: null
+        }
+      ];
+      getPopulatedAffiliationsByStateId.returns(pending);
+
+      await handler(
+        {
+          params: { stateId: 'ar' },
+          query: { status: 'pending' },
+          user: { state: { id: 'ar' } }
+        },
+        res
+      );
+
+      test.ok(res.status.notCalled, 'HTTP status not explicitly set');
+      test.ok(
+        res.send.calledWith(pending),
+        'Pending Affiliation info is sent back'
+      );
+    });
+  });
+});
+
+tap.test('GET /states/:stateId/affiliations/:id', async tests => {
+  let getPopulatedAffiliationById;
+
+  tests.beforeEach(done => {
+    app = mockExpress();
+    res = mockResponse();
+    next = sinon.stub();
+    getPopulatedAffiliationById = sinon.stub();
+    done();
+  });
+
+  tests.test('setup', async setupTest => {
+    getEndpoint(app);
+
+    setupTest.ok(
+      app.get.calledWith(
+        '/states/:stateId/affiliations/:id',
+        can('view-affiliations'),
+        sinon.match.func
+      ),
+      'specific affiliation GET endpoint is registered'
+    );
+  });
+
+  tests.test('get single affiliation handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      getEndpoint(app, { getPopulatedAffiliationById });
+      handler = app.get.args.find(
+        args => args[0] === '/states/:stateId/affiliations/:id'
+      )[2];
+      done();
+    });
+
+    handlerTest.test('database error', async t => {
+      const err = { error: 'err0r' };
+      getPopulatedAffiliationById.rejects(err);
+
+      await handler(
+        { params: { stateId: 'ar', id: '1' }, user: { state: { id: 'ar' } } },
+        res,
+        next
+      );
+
+      t.ok(next.called, 'next is called');
+      t.ok(next.calledWith(err), 'pass error to middleware');
+    });
+
+    handlerTest.test(
+      'sends an unauthorized error code if the user does not have access to the state of the affiliation',
+      async test => {
+        await handler(
+          { params: { stateId: 'ar', id: '1' }, user: { state: { id: 'fl' } } },
+          res,
+          next
+        );
+
+        test.ok(res.status.calledWith(401), 'HTTP status set to 401');
+        test.ok(res.send.notCalled, 'no body is sent');
+        test.ok(res.end.called, 'response is terminuated');
+      }
+    );
+
+    handlerTest.test(
+      'sends a not found error if there is no valid Affiliation',
+      async test => {
+        getPopulatedAffiliationById.returns(undefined);
+
+        await handler(
+          {
+            params: { stateId: 'ar', id: '100' },
+            user: { state: { id: 'ar' } }
+          },
+          res,
+          next
+        );
+
+        test.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        test.ok(res.send.notCalled, 'no body is sent');
+        test.ok(res.end.called, 'response is terminated');
+      }
+    );
+
+    handlerTest.test('sends affiliation', async test => {
+      const affiliation = {
+        id: 30,
+        userId: '00u4ofhu66rpuz7BM297',
+        stateId: 'ar',
+        status: 'revoked',
+        createdAt: '2020-12-02T18:50:56.817Z',
+        updatedAt: '2020-12-02T18:50:56.817Z',
+        updatedById: '00u4nbo8e9BoctLWI297',
+        role: 'eAPD State Coordinator',
+        updatedBy: 'Regular User',
+        displayName: 'Jesse James',
+        email: 'jjames@fearless.tech',
+        secondEmail: null,
+        primaryPhone: '1111111111',
+        mobilePhone: null
+      };
+      getPopulatedAffiliationById.returns(affiliation);
+
+      await handler(
+        { params: { stateId: 'ar', id: '30' }, user: { state: { id: 'ar' } } },
+        res
+      );
+
+      test.ok(res.status.notCalled, 'HTTP status not explicitly set');
+      test.ok(
+        res.send.calledWith(affiliation),
+        'Affiliation info is sent back'
+      );
+    });
+  });
+});

--- a/api/routes/affiliations/openAPI.js
+++ b/api/routes/affiliations/openAPI.js
@@ -35,17 +35,17 @@ const created_at = {
   type: 'string',
   format: 'date-time',
   description: 'Timestamp of record creation'
-}
+};
 
 const updated_at = {
   type: 'string',
   format: 'date-time',
   description: 'Timestamp of last update'
-}
+};
 
 const updated_by = {
   type: 'string',
-  description: 'ID of the user who last updated this record',
+  description: 'ID of the user who last updated this record'
 };
 
 const stateIdParameter = {
@@ -56,6 +56,13 @@ const stateIdParameter = {
   schema: {
     type: state_id.type
   }
+};
+
+const filterStatusParameter = {
+  name: 'status',
+  in: 'query',
+  description: 'The filter status of the affiliations for this US State',
+  enum: ['pending', 'active', 'inactive']
 };
 
 const idParameter = {
@@ -88,7 +95,7 @@ const getAffiliations = {
   get: {
     tags,
     description: 'Get a list of all user affiliations for a US State',
-    parameters: [stateIdParameter],
+    parameters: [stateIdParameter, filterStatusParameter],
     responses: {
       200: {
         description: 'List of all user affiliations for a US State',
@@ -103,7 +110,8 @@ const getAffiliations = {
 const postAffiliations = {
   post: {
     tags,
-    description: 'Create a request for the currently logged in user to be affiliated with a US State',
+    description:
+      'Create a request for the currently logged in user to be affiliated with a US State',
     parameters: [stateIdParameter],
     responses: {
       201: {
@@ -130,14 +138,14 @@ const getAffiliation = {
         content: jsonResponse(affiliationSchema)
       },
       400: {
-        description: 'The stateId and affiliation ID do not correspond to a known record'
+        description:
+          'The stateId and affiliation ID do not correspond to a known record'
       },
       ...responses.unauthed
     },
     security: [{ bearerAuth: [] }]
   }
 };
-
 
 const patchAffiliation = {
   patch: {
@@ -156,10 +164,11 @@ const patchAffiliation = {
     },
     responses: {
       200: {
-        description: 'Record was updated',
+        description: 'Record was updated'
       },
       400: {
-        description: 'US State ID and affiliation ID are invalid, roleId is invalid, or status is invalid',
+        description:
+          'US State ID and affiliation ID are invalid, roleId is invalid, or status is invalid'
       },
       ...responses.unauthed
     },
@@ -175,7 +184,7 @@ const affiliationRoutes = {
   '/states/{stateId}/affiliations/{id}': {
     ...getAffiliation,
     ...patchAffiliation
-  },
+  }
 };
 
 module.exports = affiliationRoutes;

--- a/api/routes/affiliations/openAPI.js
+++ b/api/routes/affiliations/openAPI.js
@@ -48,6 +48,12 @@ const updated_by = {
   description: 'ID of the user who last updated this record'
 };
 
+const filter_status = {
+  type: 'string',
+  description: 'The filter status of the affiliations for this US State',
+  enum: ['pending', 'active', 'inactive']
+};
+
 const stateIdParameter = {
   name: 'stateId',
   in: 'path',
@@ -59,10 +65,14 @@ const stateIdParameter = {
 };
 
 const filterStatusParameter = {
-  name: 'status',
   in: 'query',
-  description: 'The filter status of the affiliations for this US State',
-  enum: ['pending', 'active', 'inactive']
+  name: 'status',
+  description: filter_status.description,
+  required: false,
+  schema: {
+    type: filter_status.type,
+    enum: filter_status.enum
+  }
 };
 
 const idParameter = {
@@ -96,6 +106,15 @@ const getAffiliations = {
     tags,
     description: 'Get a list of all user affiliations for a US State',
     parameters: [stateIdParameter, filterStatusParameter],
+    requestBody: {
+      required: false,
+      content: jsonResponse({
+        type: 'object',
+        properties: {
+          filter_status
+        }
+      })
+    },
     responses: {
       200: {
         description: 'List of all user affiliations for a US State',

--- a/api/routes/affiliations/patch.endpoint.js
+++ b/api/routes/affiliations/patch.endpoint.js
@@ -11,18 +11,18 @@ describe('Affiliations endpoint | PATCH', () => {
   beforeAll(() => db.seed.run());
   afterAll(() => db.destroy());
 
-  unauthenticatedTest('patch', '/states/fl/affiliations/4000');
-  unauthorizedTest('patch', '/states/fl/affiliations/4000');
+  unauthenticatedTest('patch', '/states/ak/affiliations/4000');
+  unauthorizedTest('patch', '/states/ak/affiliations/4000');
 
   ['approved', 'denied', 'revoked'].forEach(status => {
     it(`returns 200, when an affiliation is ${status}`, async () => {
-      const response = await api.patch('/states/fl/affiliations/4000', {
+      const response = await api.patch('/states/ak/affiliations/4000', {
         status,
         roleId: 1106
       });
       expect(response.status).toEqual(200);
     });
-  })
+  });
 
   it('returns 400 when US state is invalid', async () => {
     const response = await api.patch('/states/zz/affiliations/4000');
@@ -30,12 +30,12 @@ describe('Affiliations endpoint | PATCH', () => {
   });
 
   it('returns 400 when affiliation id is invalid', async () => {
-    const response = await api.patch('/states/fl/affiliations/NaN');
+    const response = await api.patch('/states/ak/affiliations/NaN');
     expect(response.status).toEqual(400);
   });
 
   it('returns 400 when status is invalid', async () => {
-    const response = await api.patch('/states/fl/affiliations/4000', {
+    const response = await api.patch('/states/ak/affiliations/4000', {
       status: 'blarg',
       roleId: 1106
     });
@@ -43,7 +43,7 @@ describe('Affiliations endpoint | PATCH', () => {
   });
 
   it('returns 400 when body is invalid', async () => {
-    const response = await api.patch('/states/fl/affiliations/4000', {
+    const response = await api.patch('/states/ak/affiliations/4000', {
       status: undefined,
       roleId: undefined
     });

--- a/api/routes/affiliations/post.endpoint.js
+++ b/api/routes/affiliations/post.endpoint.js
@@ -10,12 +10,12 @@ describe('Affiliations endpoint | POST', () => {
   beforeAll(() => db.seed.run());
   afterAll(() => db.destroy());
 
-  unauthenticatedTest('post', '/states/fl/affiliations');
+  unauthenticatedTest('post', '/states/ak/affiliations');
 
   it('returns 201', async () => {
-    const response = await api.post('/states/fl/affiliations');
+    const response = await api.post('/states/ak/affiliations');
     expect(response.status).toEqual(201);
-    const keys = Object.keys(response.data)
+    const keys = Object.keys(response.data);
     expect(keys).toEqual(['id']);
   });
 

--- a/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
+++ b/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
@@ -1363,15 +1363,40 @@ Object {
           },
           Object {
             "description": "The filter status of the affiliations for this US State",
-            "enum": Array [
-              "pending",
-              "active",
-              "inactive",
-            ],
             "in": "query",
             "name": "status",
+            "required": false,
+            "schema": Object {
+              "enum": Array [
+                "pending",
+                "active",
+                "inactive",
+              ],
+              "type": "string",
+            },
           },
         ],
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "filter_status": Object {
+                    "description": "The filter status of the affiliations for this US State",
+                    "enum": Array [
+                      "pending",
+                      "active",
+                      "inactive",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+          "required": false,
+        },
         "responses": Object {
           "200": Object {
             "content": Object {

--- a/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
+++ b/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
@@ -1361,6 +1361,16 @@ Object {
               "type": "string",
             },
           },
+          Object {
+            "description": "The filter status of the affiliations for this US State",
+            "enum": Array [
+              "pending",
+              "active",
+              "inactive",
+            ],
+            "in": "query",
+            "name": "status",
+          },
         ],
         "responses": Object {
           "200": Object {

--- a/api/seeds/development.js
+++ b/api/seeds/development.js
@@ -22,7 +22,10 @@ exports.seed = async knex => {
   const emailAffiliation = {
     user_id: '00u4nbo8e9BoctLWI297',
     state_id: 'ak',
-    role_id: await knex('auth_roles').where({ name: 'eAPD State Admin' }).first().then(role => role.id),
+    role_id: await knex('auth_roles')
+      .where({ name: 'eAPD State Admin' })
+      .first()
+      .then(role => role.id),
     status: 'approved',
     updated_by: 'seeds'
   };

--- a/api/seeds/test.js
+++ b/api/seeds/test.js
@@ -21,4 +21,18 @@ exports.seed = async knex => {
   await files.seed(knex);
   await testStates.seed(knex);
   await affiliations.seed(knex);
+
+  // user: em@il.com from okta
+  // uid: 00u4nbo8e9BoctLWI297
+  const emailAffiliation = {
+    user_id: '00u4nbo8e9BoctLWI297',
+    state_id: 'fl',
+    role_id: await knex('auth_roles')
+      .where({ name: 'eAPD State Admin' })
+      .first()
+      .then(role => role.id),
+    status: 'approved',
+    updated_by: 'seeds'
+  };
+  await knex('auth_affiliations').insert(emailAffiliation);
 };

--- a/api/seeds/test/affiliations.js
+++ b/api/seeds/test/affiliations.js
@@ -16,7 +16,7 @@ exports.seed = async knex => {
     {
       id: 4000,
       user_id: 2010,
-      state_id: 'fl',
+      state_id: 'ak',
       status: 'requested'
     },
     {

--- a/api/util/states.js
+++ b/api/util/states.js
@@ -1,6 +1,6 @@
 module.exports.states = [
-  { id: 'al', name: 'Alabama' },
   { id: 'ak', name: 'Alaska' },
+  { id: 'al', name: 'Alabama' },
   { id: 'az', name: 'Arizona' },
   { id: 'ar', name: 'Arkansas' },
   { id: 'ca', name: 'California' },


### PR DESCRIPTION
Updated the /states/stateId/affiliations endpoint to have a filter option for pending, active, and inactive affiliations

### This pull request changes...

- updated the get endpoint for affiliations to have a query param called status
- updated endpoint tests and openapi to match new param

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
~- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

~- [ ] Design has approved the experience~
- [ ] Product has approved the experience
