### PR TITLE
ends the timeout and closes the alert if the user does performs an action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Anticipated release: December 21, 2020
 
 - fixed security headers
 - displays images within the tinymce editor ([#2348])
+- fixed session expiring warning bug ([#2720])
 
 #### ⚙️ Behind the scenes
 
@@ -23,11 +24,11 @@ Anticipated release: December 21, 2020
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-
 [#2348]: https://github.com/CMSgov/eAPD/issues/2348
 [#2682]: https://github.com/CMSgov/eAPD/issues/2682
 [#2583]: https://github.com/CMSgov/eAPD/issues/2583
 [#2692]: https://github.com/CMSgov/eAPD/issues/2692
 [#2702]: https://github.com/CMSgov/eAPD/issues/2702
+[#2720]: https://github.com/CMSgov/eAPD/issues/2720
 [ghsa-vrv8-v4w8-f95h]: https://github.com/advisories/GHSA-vrv8-v4w8-f95h
 [ghsa-w7rc-rwvf-8q5r]: https://github.com/advisories/GHSA-w7rc-rwvf-8q5r

--- a/api/seeds/test.js
+++ b/api/seeds/test.js
@@ -24,15 +24,29 @@ exports.seed = async knex => {
 
   // user: em@il.com from okta
   // uid: 00u4nbo8e9BoctLWI297
-  const emailAffiliation = {
-    user_id: '00u4nbo8e9BoctLWI297',
-    state_id: 'fl',
-    role_id: await knex('auth_roles')
-      .where({ name: 'eAPD State Admin' })
-      .first()
-      .then(role => role.id),
-    status: 'approved',
-    updated_by: 'seeds'
-  };
-  await knex('auth_affiliations').insert(emailAffiliation);
+  // user: reviewer from okta
+  // uid: 00u66qbf9z9TRxjmR297
+  const emailAffiliations = [
+    {
+      user_id: '00u4nbo8e9BoctLWI297',
+      state_id: 'fl',
+      role_id: await knex('auth_roles')
+        .where({ name: 'eAPD State Admin' })
+        .first()
+        .then(role => role.id),
+      status: 'approved',
+      updated_by: 'seeds'
+    },
+    {
+      user_id: '00u66qbf9z9TRxjmR297',
+      state_id: 'ak',
+      role_id: await knex('auth_roles')
+        .where({ name: 'eAPD State Admin' })
+        .first()
+        .then(role => role.id),
+      status: 'approved',
+      updated_by: 'seeds'
+    }
+  ];
+  await knex('auth_affiliations').insert(emailAffiliations);
 };

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -31,6 +31,7 @@ export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const LOGIN_FAILURE = 'LOGIN_FAILURE';
 export const LOCKED_OUT = 'LOCKED_OUT';
 export const RESET_LOCKED_OUT = 'RESET_LOCKED_OUT';
+export const LOGOUT_REQUEST = 'LOGOUT_REQUEST';
 export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS';
 
 export const STATE_ACCESS_REQUEST = 'STATE_ACCESS_REQUEST';
@@ -71,6 +72,7 @@ export const failLoginMFA = error => ({ type: LOGIN_MFA_FAILURE, error });
 export const failLoginLocked = () => ({ type: LOCKED_OUT });
 export const resetLocked = () => ({ type: RESET_LOCKED_OUT });
 
+export const requestLogout = () => ({ type: LOGOUT_REQUEST });
 export const completeLogout = () => ({ type: LOGOUT_SUCCESS });
 
 export const requestAccessToState = () => ({ type: STATE_ACCESS_REQUEST });
@@ -117,6 +119,7 @@ const getCurrentUser = () => dispatch =>
     });
 
 export const logout = () => dispatch => {
+  dispatch(requestLogout());
   logoutAndClearTokens();
   dispatch(completeLogout());
 };

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -60,6 +60,12 @@ describe('auth actions', () => {
     });
   });
 
+  it('requestLogout should create LOGOUT_REQUEST action', () => {
+    expect(actions.requestLogout()).toEqual({
+      type: actions.LOGOUT_REQUEST
+    });
+  });
+
   it('completeLogout should create LOGOUT_SUCCESS action', () => {
     expect(actions.completeLogout()).toEqual({ type: actions.LOGOUT_SUCCESS });
   });
@@ -501,7 +507,10 @@ describe('auth actions', () => {
     it('creates LOGOUT_SUCCESS after successful request', async () => {
       const store = mockStore({});
 
-      const expectedActions = [{ type: actions.LOGOUT_SUCCESS }];
+      const expectedActions = [
+        { type: actions.LOGOUT_REQUEST },
+        { type: actions.LOGOUT_SUCCESS }
+      ];
 
       await store.dispatch(actions.logout());
       expect(logoutSpy).toHaveBeenCalledTimes(1);

--- a/web/src/containers/SessionEndingAlert.js
+++ b/web/src/containers/SessionEndingAlert.js
@@ -8,10 +8,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { Spinner } from '../components/Icons';
 
 import { extendSession, logout } from '../actions/auth';
+import { isUserActive } from '../util/auth';
 
 const SessionEndingAlert = ({
   isSessionEnding,
   isExtendingSession,
+  latestActivity,
   expiresAt,
   extend,
   logoutAction
@@ -19,10 +21,11 @@ const SessionEndingAlert = ({
   const className = isSessionEnding
     ? 'alert--session-expiring__active'
     : 'alert--session-expiring__inactive';
+  const isActive = isUserActive(latestActivity);
 
   // Renderer callback with condition
   // eslint-disable-next-line react/prop-types
-  const createTimer = ({ minutes, seconds, completed }) => {
+  const createTimer = ({ minutes, seconds, completed, api }) => {
     if (completed) {
       // Render a completed state
       return (
@@ -32,6 +35,10 @@ const SessionEndingAlert = ({
           variation="error"
         />
       );
+    }
+    if (isActive) {
+      api.stop(); // eslint-disable-line react/prop-types
+      return <span />;
     }
     // Render a countdown
     return (
@@ -64,6 +71,7 @@ const SessionEndingAlert = ({
           key={uuidv4()}
           renderer={createTimer}
           onComplete={logoutAction}
+          onStop={extend}
         />
       )}
     </div>
@@ -73,16 +81,18 @@ const SessionEndingAlert = ({
 SessionEndingAlert.propTypes = {
   isSessionEnding: PropTypes.bool.isRequired,
   isExtendingSession: PropTypes.bool.isRequired,
+  latestActivity: PropTypes.bool.isRequired,
   expiresAt: PropTypes.number.isRequired,
   extend: PropTypes.func.isRequired,
   logoutAction: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({
-  auth: { isSessionEnding, isExtendingSession, expiresAt }
+  auth: { isSessionEnding, isExtendingSession, latestActivity, expiresAt }
 }) => ({
   isSessionEnding,
   isExtendingSession,
+  latestActivity,
   expiresAt
 });
 

--- a/web/src/containers/SessionEndingAlert.js
+++ b/web/src/containers/SessionEndingAlert.js
@@ -8,14 +8,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { Spinner } from '../components/Icons';
 
 import { extendSession, logout } from '../actions/auth';
-import { isUserActive } from '../util/auth';
 
 const SessionEndingAlert = ({
   isSessionEnding,
   isExtendingSession,
   isLoggingOut,
   expiresAt,
-  latestActivity,
   extend,
   logoutAction
 }) => {
@@ -24,59 +22,12 @@ const SessionEndingAlert = ({
     : 'alert--session-expiring__inactive';
 
   /* eslint-disable react/prop-types */
-  const createTimer = ({ minutes, seconds, completed, api }) => {
-    if (completed) {
-      // Render a completed state
-      return (
-        <Dialog
-          key={uuidv4()}
-          heading="Your session has ended."
-          alert
-          getApplicationNode={() =>
-            document.getElementById('session-ending-modal')
-          }
-          underlayClickExits={false}
-          escapeExitDisabled
-          size="wide"
-        >
-          Please log back in if you want to continue.
-        </Dialog>
-      );
-    }
-    if (isUserActive(latestActivity)) {
-      api.stop();
-      return <span />;
-    }
-    // Render a countdown
+  const createTimer = ({ minutes, seconds }) => {
     return (
-      <Dialog
-        key={uuidv4()}
-        heading="Your session is expiring."
-        alert
-        getApplicationNode={() =>
-          document.getElementById('session-ending-modal')
-        }
-        actionsClassName="ds-u-text-align--right ds-u-margin-bottom--0"
-        actions={[
-          <Button variation="primary" onClick={extend} key={uuidv4()}>
-            {isExtendingSession && <Spinner />}
-            {isExtendingSession ? ' Continuing' : 'Continue'}
-          </Button>,
-          <Button variation="transparent" onClick={logoutAction} key={uuidv4()}>
-            {isLoggingOut && <Spinner />}
-            {isLoggingOut ? ' Signing out' : 'Sign out'}
-          </Button>
-        ]}
-        ariaCloseLabel="Close and continue"
-        closeText="Close"
-        onExit={extend}
-        underlayClickExits={false}
-        escapeExitDisabled
-        size="wide"
-      >
+      <span>
         Your session will end in {zeroPad(minutes)}:{zeroPad(seconds)} minutes.
         If you’d like to keep working, choose continue.
-      </Dialog>
+      </span>
     );
   };
 
@@ -88,13 +39,43 @@ const SessionEndingAlert = ({
     >
       <div id="session-ending-modal" />
       {isSessionEnding && (
-        <Countdown
-          date={expiresAt - 5000}
+        <Dialog
           key={uuidv4()}
-          renderer={createTimer}
-          onComplete={logoutAction}
-          onStop={extend}
-        />
+          heading="Your session is expiring."
+          alert
+          getApplicationNode={() =>
+            document.getElementById('session-ending-modal')
+          }
+          actionsClassName="ds-u-text-align--right ds-u-margin-bottom--0"
+          actions={[
+            <Button variation="primary" onClick={extend} key={uuidv4()}>
+              {isExtendingSession && <Spinner />}
+              {isExtendingSession ? ' Continuing' : 'Continue'}
+            </Button>,
+            <Button
+              variation="transparent"
+              onClick={logoutAction}
+              key={uuidv4()}
+            >
+              {isLoggingOut && <Spinner />}
+              {isLoggingOut ? ' Signing out' : 'Sign out'}
+            </Button>
+          ]}
+          ariaCloseLabel="Close and continue"
+          closeText="Close"
+          onExit={extend}
+          underlayClickExits={false}
+          escapeExitDisabled
+          size="wide"
+        >
+          <Countdown
+            date={expiresAt - 5000}
+            key={uuidv4()}
+            renderer={createTimer}
+            onComplete={logoutAction}
+            onStop={extend}
+          />
+        </Dialog>
       )}
     </div>
   );
@@ -104,25 +85,17 @@ SessionEndingAlert.propTypes = {
   isSessionEnding: PropTypes.bool.isRequired,
   isExtendingSession: PropTypes.bool.isRequired,
   isLoggingOut: PropTypes.bool.isRequired,
-  latestActivity: PropTypes.number.isRequired,
   expiresAt: PropTypes.number.isRequired,
   extend: PropTypes.func.isRequired,
   logoutAction: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({
-  auth: {
-    isSessionEnding,
-    isExtendingSession,
-    isLoggingOut,
-    latestActivity,
-    expiresAt
-  }
+  auth: { isSessionEnding, isExtendingSession, isLoggingOut, expiresAt }
 }) => ({
   isSessionEnding,
   isExtendingSession,
   isLoggingOut,
-  latestActivity,
   expiresAt
 });
 

--- a/web/src/containers/SessionEndingAlert.test.js
+++ b/web/src/containers/SessionEndingAlert.test.js
@@ -1,4 +1,4 @@
-import { renderWithConnection } from 'apd-testing-library';
+import { renderWithConnection, waitFor } from 'apd-testing-library';
 import React from 'react';
 
 import SessionEndingAlert, {
@@ -20,6 +20,7 @@ describe('the session ending alert component', () => {
           auth: {
             isSessionEnding: false,
             isExtendingSession: false,
+            latestActivity: new Date().getTime(),
             expiresAt: new Date().getTime() + 60000
           }
         }
@@ -36,6 +37,7 @@ describe('the session ending alert component', () => {
           auth: {
             isSessionEnding: true,
             isExtendingSession: false,
+            latestActivity: new Date().getTime() - 300000,
             expiresAt: new Date().getTime() + 60000
           }
         }
@@ -43,6 +45,25 @@ describe('the session ending alert component', () => {
     );
     expect(container.firstChild).toHaveAttribute('aria-hidden', 'false');
     expect(getByRole('button', { name: 'Continue' })).toBeTruthy();
+  });
+
+  it('renders as expected if session is ending and session is not being extended, but new activity', async () => {
+    const { container } = renderWithConnection(
+      <SessionEndingAlert {...props} />,
+      {
+        initialState: {
+          auth: {
+            isSessionEnding: true,
+            isExtendingSession: false,
+            latestActivity: new Date().getTime(),
+            expiresAt: new Date().getTime() + 60000
+          }
+        }
+      }
+    );
+    await waitFor(() =>
+      expect(container.firstChild).toHaveAttribute('aria-hidden', 'true')
+    );
   });
 
   it('renders as expected if there is and error and is saving', () => {
@@ -53,6 +74,7 @@ describe('the session ending alert component', () => {
           auth: {
             isSessionEnding: true,
             isExtendingSession: true,
+            latestActivity: new Date().getTime() - 300000,
             expiresAt: new Date().getTime() + 60000
           }
         }
@@ -63,16 +85,22 @@ describe('the session ending alert component', () => {
   });
 
   it('maps redux state to component props', () => {
+    const latestActivity = new Date().getTime();
+    const expiresAt = new Date().getTime + 60000;
     expect(
       mapStateToProps({
         auth: {
           isSessionEnding: false,
-          isExtendingSession: false
+          isExtendingSession: false,
+          latestActivity,
+          expiresAt
         }
       })
     ).toEqual({
       isSessionEnding: false,
-      isExtendingSession: false
+      isExtendingSession: false,
+      latestActivity,
+      expiresAt
     });
   });
 

--- a/web/src/containers/SessionEndingAlert.test.js
+++ b/web/src/containers/SessionEndingAlert.test.js
@@ -1,87 +1,140 @@
-import { renderWithConnection, waitFor } from 'apd-testing-library';
 import React from 'react';
+import { shallow } from 'enzyme';
 
-import SessionEndingAlert, {
+import {
+  plain as SessionEndingAlert,
   mapStateToProps,
   mapDispatchToProps
 } from './SessionEndingAlert';
-import { setLatestActivity, extendSession, logout } from '../actions/auth';
-
-const props = {
-  extend: jest.fn()
-};
+import { extendSession, logout } from '../actions/auth';
 
 describe('the session ending alert component', () => {
   it('render as expected if session is not ending and session is not being extended', () => {
-    const { container } = renderWithConnection(
-      <SessionEndingAlert {...props} />,
-      {
-        initialState: {
-          auth: {
-            isSessionEnding: false,
-            isExtendingSession: false,
-            latestActivity: new Date().getTime(),
-            expiresAt: new Date().getTime() + 60000
-          }
-        }
-      }
-    );
-    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+    const props = {
+      isSessionEnding: false,
+      isExtendingSession: false,
+      isLoggingOut: false,
+      latestActivity: new Date().getTime(),
+      expiresAt: new Date().getTime() + 60000,
+      extend: jest.fn(),
+      logoutAction: jest.fn()
+    };
+    const component = shallow(<SessionEndingAlert {...props} />);
+    expect(component.children().length).toEqual(1);
+    expect(component.exists('#react-aria-modal-dialog')).toBe(false);
   });
 
-  it('renders as expected if session is ending and session is not being extended', () => {
-    const { container, getByRole } = renderWithConnection(
-      <SessionEndingAlert {...props} />,
-      {
-        initialState: {
-          auth: {
-            isSessionEnding: true,
-            isExtendingSession: false,
-            latestActivity: new Date().getTime() - 300000,
-            expiresAt: new Date().getTime() + 60000
-          }
-        }
-      }
-    );
-    expect(container.firstChild).toHaveAttribute('aria-hidden', 'false');
-    expect(getByRole('button', { name: 'Continue' })).toBeTruthy();
+  it('renders as expected if session is ending and session is not being extended', async () => {
+    const props = {
+      isSessionEnding: true,
+      isExtendingSession: false,
+      isLoggingOut: false,
+      latestActivity: new Date().getTime() - 300000,
+      expiresAt: new Date().getTime() + 60000,
+      extend: jest.fn(),
+      logoutAction: jest.fn()
+    };
+    const component = shallow(<SessionEndingAlert {...props} />);
+    expect(component.childAt(1)).toBeTruthy();
+    const countdown = component
+      .childAt(1)
+      .dive()
+      .dive();
+    const aside = countdown.find('aside');
+    expect(
+      aside
+        .childAt(0)
+        .dive()
+        .text()
+    ).toEqual('Continue');
+    expect(
+      aside
+        .childAt(1)
+        .dive()
+        .text()
+    ).toEqual('Sign out');
   });
 
   it('renders as expected if session is ending and session is not being extended, but new activity', async () => {
-    const { container } = renderWithConnection(
-      <SessionEndingAlert {...props} />,
-      {
-        initialState: {
-          auth: {
-            isSessionEnding: true,
-            isExtendingSession: false,
-            latestActivity: new Date().getTime(),
-            expiresAt: new Date().getTime() + 60000
-          }
-        }
-      }
-    );
-    await waitFor(() =>
-      expect(container.firstChild).toHaveAttribute('aria-hidden', 'true')
-    );
+    const props = {
+      isSessionEnding: true,
+      isExtendingSession: false,
+      isLoggingOut: false,
+      latestActivity: new Date().getTime(),
+      expiresAt: new Date().getTime() + 60000,
+      extend: jest.fn(),
+      logoutAction: jest.fn()
+    };
+
+    const component = shallow(<SessionEndingAlert {...props} />);
+    expect(
+      component
+        .childAt(1)
+        .dive()
+        .equals(<span />)
+    ).toBeTruthy();
   });
 
   it('renders as expected if there is and error and is saving', () => {
-    const { container, getByRole } = renderWithConnection(
-      <SessionEndingAlert {...props} />,
-      {
-        initialState: {
-          auth: {
-            isSessionEnding: true,
-            isExtendingSession: true,
-            latestActivity: new Date().getTime() - 300000,
-            expiresAt: new Date().getTime() + 60000
-          }
-        }
-      }
-    );
-    expect(container.firstChild).toHaveAttribute('aria-hidden', 'false');
-    expect(getByRole('button', { name: 'Continuing' })).toBeTruthy();
+    const props = {
+      isSessionEnding: true,
+      isExtendingSession: true,
+      isLoggingOut: false,
+      latestActivity: new Date().getTime() - 300000,
+      expiresAt: new Date().getTime() + 60000,
+      extend: jest.fn(),
+      logoutAction: jest.fn()
+    };
+    const component = shallow(<SessionEndingAlert {...props} />);
+    expect(component.childAt(1)).toBeTruthy();
+    const countdown = component
+      .childAt(1)
+      .dive()
+      .dive();
+    const aside = countdown.find('aside');
+    expect(
+      aside
+        .childAt(0)
+        .dive()
+        .text()
+    ).toEqual('<Spinner /> Continuing');
+    expect(
+      aside
+        .childAt(1)
+        .dive()
+        .text()
+    ).toEqual('Sign out');
+  });
+
+  it('renders as expected if there is and error and is signing out', () => {
+    const props = {
+      isSessionEnding: true,
+      isExtendingSession: false,
+      isLoggingOut: true,
+      latestActivity: new Date().getTime() - 300000,
+      expiresAt: new Date().getTime() + 60000,
+      extend: jest.fn(),
+      logoutAction: jest.fn()
+    };
+    const component = shallow(<SessionEndingAlert {...props} />);
+    expect(component.childAt(1)).toBeTruthy();
+    const countdown = component
+      .childAt(1)
+      .dive()
+      .dive();
+    const aside = countdown.find('aside');
+    expect(
+      aside
+        .childAt(0)
+        .dive()
+        .text()
+    ).toEqual('Continue');
+    expect(
+      aside
+        .childAt(1)
+        .dive()
+        .text()
+    ).toEqual('<Spinner /> Signing out');
   });
 
   it('maps redux state to component props', () => {
@@ -92,6 +145,7 @@ describe('the session ending alert component', () => {
         auth: {
           isSessionEnding: false,
           isExtendingSession: false,
+          isLoggingOut: false,
           latestActivity,
           expiresAt
         }
@@ -99,6 +153,7 @@ describe('the session ending alert component', () => {
     ).toEqual({
       isSessionEnding: false,
       isExtendingSession: false,
+      isLoggingOut: false,
       latestActivity,
       expiresAt
     });
@@ -107,8 +162,7 @@ describe('the session ending alert component', () => {
   it('maps redux actions to component props', () => {
     expect(mapDispatchToProps).toEqual({
       extend: extendSession,
-      logoutAction: logout,
-      latestActivityAction: setLatestActivity
+      logoutAction: logout
     });
   });
 });

--- a/web/src/containers/SessionEndingAlert.test.js
+++ b/web/src/containers/SessionEndingAlert.test.js
@@ -5,7 +5,7 @@ import SessionEndingAlert, {
   mapStateToProps,
   mapDispatchToProps
 } from './SessionEndingAlert';
-import { extendSession, logout } from '../actions/auth';
+import { setLatestActivity, extendSession, logout } from '../actions/auth';
 
 const props = {
   extend: jest.fn()
@@ -107,7 +107,8 @@ describe('the session ending alert component', () => {
   it('maps redux actions to component props', () => {
     expect(mapDispatchToProps).toEqual({
       extend: extendSession,
-      logoutAction: logout
+      logoutAction: logout,
+      latestActivityAction: setLatestActivity
     });
   });
 });

--- a/web/src/containers/SessionEndingAlert.test.js
+++ b/web/src/containers/SessionEndingAlert.test.js
@@ -114,7 +114,6 @@ describe('the session ending alert component', () => {
   });
 
   it('maps redux state to component props', () => {
-    const latestActivity = new Date().getTime();
     const expiresAt = new Date().getTime + 60000;
     expect(
       mapStateToProps({

--- a/web/src/containers/SessionEndingAlert.test.js
+++ b/web/src/containers/SessionEndingAlert.test.js
@@ -14,7 +14,6 @@ describe('the session ending alert component', () => {
       isSessionEnding: false,
       isExtendingSession: false,
       isLoggingOut: false,
-      latestActivity: new Date().getTime(),
       expiresAt: new Date().getTime() + 60000,
       extend: jest.fn(),
       logoutAction: jest.fn()
@@ -29,7 +28,6 @@ describe('the session ending alert component', () => {
       isSessionEnding: true,
       isExtendingSession: false,
       isLoggingOut: false,
-      latestActivity: new Date().getTime() - 300000,
       expiresAt: new Date().getTime() + 60000,
       extend: jest.fn(),
       logoutAction: jest.fn()
@@ -55,32 +53,11 @@ describe('the session ending alert component', () => {
     ).toEqual('Sign out');
   });
 
-  it('renders as expected if session is ending and session is not being extended, but new activity', async () => {
-    const props = {
-      isSessionEnding: true,
-      isExtendingSession: false,
-      isLoggingOut: false,
-      latestActivity: new Date().getTime(),
-      expiresAt: new Date().getTime() + 60000,
-      extend: jest.fn(),
-      logoutAction: jest.fn()
-    };
-
-    const component = shallow(<SessionEndingAlert {...props} />);
-    expect(
-      component
-        .childAt(1)
-        .dive()
-        .equals(<span />)
-    ).toBeTruthy();
-  });
-
   it('renders as expected if there is and error and is saving', () => {
     const props = {
       isSessionEnding: true,
       isExtendingSession: true,
       isLoggingOut: false,
-      latestActivity: new Date().getTime() - 300000,
       expiresAt: new Date().getTime() + 60000,
       extend: jest.fn(),
       logoutAction: jest.fn()
@@ -111,7 +88,6 @@ describe('the session ending alert component', () => {
       isSessionEnding: true,
       isExtendingSession: false,
       isLoggingOut: true,
-      latestActivity: new Date().getTime() - 300000,
       expiresAt: new Date().getTime() + 60000,
       extend: jest.fn(),
       logoutAction: jest.fn()
@@ -146,7 +122,6 @@ describe('the session ending alert component', () => {
           isSessionEnding: false,
           isExtendingSession: false,
           isLoggingOut: false,
-          latestActivity,
           expiresAt
         }
       })
@@ -154,7 +129,6 @@ describe('the session ending alert component', () => {
       isSessionEnding: false,
       isExtendingSession: false,
       isLoggingOut: false,
-      latestActivity,
       expiresAt
     });
   });

--- a/web/src/reducers/auth.js
+++ b/web/src/reducers/auth.js
@@ -12,6 +12,7 @@ import {
   LOGIN_FAILURE,
   LOCKED_OUT,
   RESET_LOCKED_OUT,
+  LOGOUT_REQUEST,
   LOGOUT_SUCCESS,
   STATE_ACCESS_REQUEST,
   STATE_ACCESS_SUCCESS,
@@ -42,6 +43,7 @@ const initialState = {
   selectState: false,
   isLocked: false,
   latestActivity: new Date().getTime(),
+  isLoggingOut: false,
   isSessionEnding: false,
   isExtendingSession: false,
   user: null,
@@ -155,6 +157,11 @@ const auth = (state = initialState, action) => {
         fetching: false,
         error: ''
       };
+    case LOGOUT_REQUEST:
+      return {
+        ...state,
+        isLoggingOut: true
+      };
     case LOGOUT_SUCCESS:
       return {
         ...initialState,
@@ -164,7 +171,8 @@ const auth = (state = initialState, action) => {
         latestActivity: null,
         expiresAt: null,
         isSessionEnding: false,
-        isExtendingSession: false
+        isExtendingSession: false,
+        isLoggingOut: false
       };
     case STATE_ACCESS_REQUEST:
       return {

--- a/web/src/reducers/auth.test.js
+++ b/web/src/reducers/auth.test.js
@@ -12,6 +12,7 @@ import {
   LOGIN_SUCCESS,
   LOGIN_FAILURE,
   LOGIN_MFA_FAILURE,
+  LOGOUT_REQUEST,
   LOGOUT_SUCCESS,
   LOCKED_OUT,
   RESET_LOCKED_OUT,
@@ -42,6 +43,7 @@ describe('auth reducer', () => {
     selectState: false,
     mfaEnrollType: '',
     isLocked: false,
+    isLoggingOut: false,
     latestActivity: null,
     isSessionEnding: false,
     isExtendingSession: false,
@@ -196,12 +198,25 @@ describe('auth reducer', () => {
     });
   });
 
+  it('should handle LOGOUT_REQUEST', () => {
+    expect(auth(initialState, { type: LOGOUT_REQUEST })).toEqual({
+      ...initialState,
+      isLoggingOut: true
+    });
+  });
+
   it('should handle LOGOUT_SUCCESS', () => {
     expect(auth(initialState, { type: LOGOUT_SUCCESS })).toEqual({
       ...initialState,
       otpStage: false,
       hasEverLoggedOn: false,
-      initialCheck: false
+      initialCheck: false,
+      authenticated: false,
+      latestActivity: null,
+      expiresAt: null,
+      isSessionEnding: false,
+      isExtendingSession: false,
+      isLoggingOut: false
     });
   });
 
@@ -222,6 +237,7 @@ describe('auth reducer', () => {
         initialCheck: true,
         otpStage: false,
         isLocked: false,
+        isLoggingOut: false,
         user: null,
         requestAccess: false,
         requestAccessSuccess: false,


### PR DESCRIPTION
### This pull request changes...

- a modal should pop up and the user should not be able to escape or click outside of it to close it
- clicking the X button should close the modal and continue the session
- clicking Continue should continue the session
- clicking Sign out should sign the user out of the session and return them to the login screen

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
~- [ ] The change has been documented~
~- [ ] Associated OpenAPI documentation has been updated~
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
