### PR TITLE
Tbolt/2724 outcomes and metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next release
 
-Anticipated release: December 21, 2020
+Anticipated release: January 8, 2021
 
 #### 🚀 New features
 
@@ -8,6 +8,7 @@ Anticipated release: December 21, 2020
 - Adds State Admin panel ([#2583])
 - Updated roles and add roles endpoint ([#2692])
 - Update session management to warn users that their session is about to expire ([#2702])
+- Increases outcomes and metrics field size to be multiline (4) ([#2724])
 
 #### 🐛 Bugs fixed
 
@@ -30,5 +31,6 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#2692]: https://github.com/CMSgov/eAPD/issues/2692
 [#2702]: https://github.com/CMSgov/eAPD/issues/2702
 [#2720]: https://github.com/CMSgov/eAPD/issues/2720
+[#2724]: https://github.com/CMSgov/eAPD/issues/2724
 [ghsa-vrv8-v4w8-f95h]: https://github.com/advisories/GHSA-vrv8-v4w8-f95h
 [ghsa-w7rc-rwvf-8q5r]: https://github.com/advisories/GHSA-w7rc-rwvf-8q5r

--- a/web/src/containers/activity/OutcomesAndMetrics/OutcomeAndMetricForm.js
+++ b/web/src/containers/activity/OutcomesAndMetrics/OutcomeAndMetricForm.js
@@ -37,6 +37,8 @@ const OutcomeAndMetricForm = ({
         label="Outcome"
         hint="Describe a discrete and measurable improvement for this system."
         value={outcome}
+        multiline
+        rows="4"
         onChange={changeOutcome}
       />
 
@@ -58,6 +60,8 @@ const OutcomeAndMetricForm = ({
               label="Metric"
               hint="Describe a measure that would demonstrate whether this system is meeting this outcome."
               value={metric}
+              multiline
+              rows="4"
               onChange={changeMetric(i)}
             />
           </div>

--- a/web/src/containers/activity/OutcomesAndMetrics/__snapshots__/OutcomeAndMetricForm.test.js.snap
+++ b/web/src/containers/activity/OutcomesAndMetrics/__snapshots__/OutcomeAndMetricForm.test.js.snap
@@ -7,8 +7,10 @@ exports[`the OutcomeAndMetricForm component renders correctly 1`] = `
     className="data-entry-box"
     hint="Describe a discrete and measurable improvement for this system."
     label="Outcome"
+    multiline={true}
     name="outcome"
     onChange={[Function]}
+    rows="4"
     type="text"
     value="outcome description"
   />
@@ -25,8 +27,10 @@ exports[`the OutcomeAndMetricForm component renders correctly 1`] = `
       <TextField
         hint="Describe a measure that would demonstrate whether this system is meeting this outcome."
         label="Metric"
+        multiline={true}
         name="metric"
         onChange={[Function]}
+        rows="4"
         type="text"
         value="metric 1"
       />
@@ -45,8 +49,10 @@ exports[`the OutcomeAndMetricForm component renders correctly 1`] = `
       <TextField
         hint="Describe a measure that would demonstrate whether this system is meeting this outcome."
         label="Metric"
+        multiline={true}
         name="metric"
         onChange={[Function]}
+        rows="4"
         type="text"
         value="metric 2"
       />


### PR DESCRIPTION
Resolves #2724 

### This pull request changes...

- The outcomes and metrics fields to be a larger

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
