### PR TITLE
work around for issue with logging in

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2952,9 +2952,9 @@
       }
     },
     "@okta/okta-auth-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-4.4.0.tgz",
-      "integrity": "sha512-D5klXjyT3qRgWDJspoSNzyKvw+NpDsfbCF9qUTK7nZGqqfOIt9VaEtzX3zd8M+zo5dOIu7Snsv2XqcJxpcmiSw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-4.6.1.tgz",
+      "integrity": "sha512-D7RRI356IAoKORDuxfK6Kd9ipoZxPYNlWkR1N0UhTMHOhsQ8PSfjCQy4z/pYCnD6AtaZRbjq0KQfTQrzIq2+rA==",
       "requires": {
         "Base64": "0.3.0",
         "core-js": "^3.6.5",
@@ -2969,9 +2969,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
-          "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg=="
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
         }
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -63,7 +63,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
-    "@okta/okta-auth-js": "^4.4.0",
+    "@okta/okta-auth-js": "^4.6.1",
     "@tinymce/tinymce-react": "^3.9.0",
     "axios": "^0.21.1",
     "connected-react-router": "^6.8.0",

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -183,12 +183,12 @@ export const mfaAddPhone = mfaSelected => async dispatch => {
 export const mfaActivate = code => async dispatch => {
   const transaction = await retrieveExistingTransaction();
 
-  const activateTransaciton = await transaction.activate({
+  const activateTransaction = await transaction.activate({
     passCode: code
   });
 
-  if (activateTransaciton.status === 'SUCCESS') {
-    const expiresAt = await setTokens(activateTransaciton.sessionToken);
+  if (activateTransaction.status === 'SUCCESS') {
+    const expiresAt = await setTokens(activateTransaction.sessionToken);
     dispatch(setupTokenManager());
     dispatch(updateSessionExpiration(expiresAt));
     dispatch(getCurrentUser());

--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -18,7 +18,7 @@ const ConsentBanner = ({ onAgree }) => {
   const [showDetails, setShowDetails] = useState(false);
 
   const agreeAndContinue = () => {
-    document.cookie = 'gov.cms.eapd.hasConsented=true;max-age=259200'; // 3 days
+    document.cookie = 'gov.cms.eapd.hasConsented=true; max-age=259200; secure'; // 3 days
     onAgree();
   };
 

--- a/web/src/util/auth.js
+++ b/web/src/util/auth.js
@@ -39,13 +39,13 @@ export const setTokens = sessionToken => {
       // prompt: 'none'
     })
     .then(async res => {
-      const { state: responseToken, tokens } = res;
-      if (stateToken === responseToken) {
-        await oktaAuth.tokenManager.setTokens(tokens);
-        const expiresAt = await getSessionExpiration();
-        return expiresAt;
-      }
-      throw new Error('Authentication failed');
+      const { tokens } = res;
+      // if (stateToken === responseToken) { // state not currently being returned
+      await oktaAuth.tokenManager.setTokens(tokens);
+      const expiresAt = await getSessionExpiration();
+      return expiresAt;
+      // }
+      // throw new Error('Authentication failed');
     });
 };
 


### PR DESCRIPTION
There has been a change in how Okta is handling getting token. Currently they aren't returning state in the response, so we can't compare it to what was sent in. I tested it against my dev instance of Okta too, so it's not just an issue with our CMS set up. I have created an issue with okta-auth-js.

This change should be invisible to the end user.

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
~- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
~- [ ] The change has been documented~
~- [ ] Associated OpenAPI documentation has been updated~
~- [ ] Changelog is updated as appropriate~

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
