### PR TITLE
updates state dashboard with eAPD logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Anticipated release: January 21, 2021
 - Uses "CMS eAPD" for page title and header title ([#2780])
 - Update form field labels for the Activity Private Contractor Costs form ([#2742])
 - Updates FTE Allocation Help text ([#2743])
+- Swaps My State Dashboard title with eAPD logo ([#2776])
 
 
 #### 🐛 Bugs fixed
@@ -60,6 +61,7 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#2736]: https://github.com/CMSgov/eAPD/issues/2736
 [#2780]: https://github.com/CMSgov/eAPD/issues/2780
 [#2743]: https://github.com/CMSgov/eAPD/issues/2743
+[#2776]: https://github.com/CMSgov/eAPD/issues/2776
 
 [ghsa-vrv8-v4w8-f95h]: https://github.com/advisories/GHSA-vrv8-v4w8-f95h
 [ghsa-w7rc-rwvf-8q5r]: https://github.com/advisories/GHSA-w7rc-rwvf-8q5r

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,67 +1,20 @@
 # Next release
 
-Anticipated release: January 21, 2021
+Anticipated release: January 25, 2021
 
 #### 🚀 New features
 
-- Adds confirmation dialog before unchecking FFY year([#2445])
-- Adds State Admin panel ([#2583])
-- Update endpoint for affiliations to filter by status ([#2682])
-- Updated roles and add roles endpoint ([#2692])
-- Update session management to warn users that their session is about to expire ([#2702])
-- Updates logos in footer ([#2716])
-- Increases outcomes and metrics field size to be multiline (4) ([#2724])
-- Resolve TinyMCE XSS vulnerabilities ([#2741])
-- Updates Previous Activities tables to use clearer headings ([#2744])
-- Updates to program summary page ([#2736])
-- Uses "CMS eAPD" for page title and header title ([#2780])
-- Update form field labels for the Activity Private Contractor Costs form ([#2742])
-- Updates FTE Allocation Help text ([#2743])
 - Swaps My State Dashboard title with eAPD logo ([#2776])
 
 
 #### 🐛 Bugs fixed
 
-- fixed security headers
-- fixed Estimated Quarterly Expenditure table is overwriting across Activities ([#2421])
-- displays images within the tinymce editor ([#2348])
-- updates footer email address to correct one ([#2353])
-- fixed issue with Back to APD link not displaying ([#2712])
-- fixes issue where removing a FFY from program summary wouldn't remove it from the read-only view ([#2715])
-- fixed session expiring warning bug ([#2720])
-- activity creation does not add outcomes or milestones ([2725])
-
 
 #### ⚙️ Behind the scenes
 
-- patches tinymce XSS vulnerability; enables media plugin ([GHSA-vrv8-v4w8-f95h])
-- upgrades `@okta/okta-sdk-nodejs`; resolves ([GHSA-w7rc-rwvf-8q5r])
 
 # Previous releases
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-[#2348]: https://github.com/CMSgov/eAPD/issues/2348
-[#2353]: https://github.com/CMSgov/eAPD/issues/2353
-[#2445]: https://github.com/CMSgov/eAPD/issues/2445
-[#2583]: https://github.com/CMSgov/eAPD/issues/2583
-[#2682]: https://github.com/CMSgov/eAPD/issues/2682
-[#2692]: https://github.com/CMSgov/eAPD/issues/2692
-[#2702]: https://github.com/CMSgov/eAPD/issues/2702
-[#2712]: https://github.com/CMSgov/eAPD/issues/2712
-[#2715]: https://github.com/CMSgov/eAPD/issues/2715
-[#2716]: https://github.com/CMSgov/eAPD/issues/2716
-[#2720]: https://github.com/CMSgov/eAPD/issues/2720
-[#2724]: https://github.com/CMSgov/eAPD/issues/2724
-[#2725]: https://github.com/CMSgov/eAPD/issues/2725
-[#2741]: https://github.com/CMSgov/eAPD/issues/2741
-[#2742]: https://github.com/CMSgov/eAPD/issues/2742
-[#2716]: https://github.com/CMSgov/eAPD/issues/2716
-[#2744]: https://github.com/CMSgov/eAPD/issues/2744
-[#2736]: https://github.com/CMSgov/eAPD/issues/2736
-[#2780]: https://github.com/CMSgov/eAPD/issues/2780
-[#2743]: https://github.com/CMSgov/eAPD/issues/2743
 [#2776]: https://github.com/CMSgov/eAPD/issues/2776
-
-[ghsa-vrv8-v4w8-f95h]: https://github.com/advisories/GHSA-vrv8-v4w8-f95h
-[ghsa-w7rc-rwvf-8q5r]: https://github.com/advisories/GHSA-w7rc-rwvf-8q5r

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -124,12 +124,13 @@ const StateDashboard = (
           <div className="ds-u-padding-top--2">
             <UpgradeBrowser />
             <div className="ds-l-row ds-u-margin-top--7">
-              <div className="ds-l-col--8 ds-u-margin-x--auto ">
-                <h1 className="ds-h1">
-                  {t('stateDashboard.title', {
-                    state: state ? state.name : ''
-                  })}
-                </h1>
+              <div className="ds-l-col--8 ds-u-margin-x--auto">
+                <div className="ds-u-display--flex ds-u-justify-content--center" data-testid="eAPDlogo">
+                  <img
+                    src="/static/img/eAPDLogoSVG:ICO/SVG/eAPDColVarSVG.svg"
+                    alt="eAPD Logo"
+                  />
+                </div>
                 <Instruction source="stateDashboard.introduction" />
                 {stateStatus === STATE_AFFILIATION_STATUSES.APPROVED && (
                   <Instruction source="stateDashboard.instruction" />

--- a/web/src/containers/StateDashboard.test.js
+++ b/web/src/containers/StateDashboard.test.js
@@ -52,6 +52,11 @@ describe('<StateDashboard />', () => {
       });
     });
 
+    it('should display the eAPD Logo', () => {
+      const { getByTestId } = renderUtils;
+      expect(getByTestId('eAPDlogo')).toBeTruthy();
+    });
+
     it('should display introduction, but not instruction', () => {
       const { queryByText } = renderUtils;
       expect(


### PR DESCRIPTION
Resolves #2776 

### This pull request changes...

- Updates state dashboard landing with eAPD logo per design

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
