### PR TITLE
Adding splunk user to ec2-user group to read /home/ec2-user logs

### DIFF
--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -115,6 +115,7 @@ function createNewInstance() {
     --subnet-id "$AWS_SUBNET" \
     --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}}]" \
     --user-data file://aws.user-data.sh \
+    --key-name eapd_bbrooks \
     | jq -r -c '.Instances[0].InstanceId'
 }
 

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -17,6 +17,9 @@ mkdir /app/tls
 amazon-linux-extras install nginx1.12
 yum -y install git postgresql-server amazon-cloudwatch-agent
 
+# Add the Splunk user to the ec2-user group so that it can read logs in /home/ec2-user
+usermod -a -G ec2-user splunk
+
 # Setup postgres
 service postgresql initdb
 echo "

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -11,6 +11,9 @@ chmod g+w /app
 # Oddly, EC2 images don't have git installed. Shruggy person.
 yum -y install git
 
+# Add the Splunk user to the ec2-user group so that it can read logs in /home/ec2-user
+usermod -a -G ec2-user splunk
+
 #Install CloudWatch Agent
 wget https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
 


### PR DESCRIPTION
This Pull Request should add the splunk user to the ec2-usger group so that it can access application logs and logs stored in /home/ec2-user

### This pull request changes...

- Adds the splunk user to the ec2-user group
- Allows the splunk user to access the logs in /home/ec2-user and all of the logs provided to the Splunk team via spreadsheet

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
