### PR TITLE
Bbrooks/1503 splunk move pm2 logs

### DIFF
--- a/api/logger/winston.js
+++ b/api/logger/winston.js
@@ -1,3 +1,5 @@
+var path =
+
 require('../env');
 const fs = require('fs');
 const winston = require('winston');
@@ -15,7 +17,7 @@ const formats = [
 const transports = [
   LOG_CONSOLE === 'true' && new winston.transports.Console(),
   LOG_FILE === 'true' &&
-    new winston.transports.File({ filename: `${packageName}.log` }),
+    new winston.transports.File({ filename: `/app/api/logs/${packageName}.log` }),
   new winston.transports.Stream({ stream: fs.createWriteStream('/dev/null') })
   // new AwsCloudWatch(options);
 ].filter(Boolean);

--- a/api/logger/winston.js
+++ b/api/logger/winston.js
@@ -1,5 +1,3 @@
-var path =
-
 require('../env');
 const fs = require('fs');
 const winston = require('winston');

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -7,6 +7,7 @@ gpasswd -a ec2-user eapd
 mkdir /app
 mkdir /app/api
 mkdir /app/web
+mkdir -p /app/api/logs
 
 chown -R :eapd /app
 chmod -R g+w /app

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -274,6 +274,10 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
             "log_group_name": "preview/app/api/logs/eAPD-API-out-0.log"
           },
           {
+            "file_path": "/app/api/logs/eAPD-API-*",
+            "log_group_name": "preview/app/api/logs/eAPD-API-combined-0.log"
+          },          
+          {
             "file_path": "/app/api/logs/Database-migration-error.log*",
             "log_group_name": "preview/app/api/logs/Database-migration-error.log"
           },
@@ -282,13 +286,21 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
             "log_group_name": "preview/app/api/logs/Database-migration-out.log"
           },
           {
+            "file_path": "/app/api/logs/Database-migration-*",
+            "log_group_name": "preview/app/api/logs/Database-migration-combined.log"
+          },          
+          {
             "file_path": "/app/api/logs/Database-seeding-error.log*",
             "log_group_name": "preview/app/api/logs/Database-seeding-error.log"
           },
           {
             "file_path": "/app/api/logs/Database-seeding-out.log*",
             "log_group_name": "preview/app/api/logs/Database-seeding-out.log"
-          },                                        
+          },
+          {
+            "file_path": "/app/api/logs/Database-seeding-*",
+            "log_group_name": "preview/app/api/logs/Database-seeding-combined.log"
+          },                                           
           {
             "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
             "log_group_name": "preview/app/api/logs/cms-hitech-apd-api.logs"              

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -17,9 +17,6 @@ mkdir /app/tls
 amazon-linux-extras install nginx1.12
 yum -y install git postgresql-server amazon-cloudwatch-agent
 
-# Add the Splunk user to the ec2-user group so that it can read logs in /home/ec2-user
-usermod -a -G ec2-user splunk
-
 # Setup postgres
 service postgresql initdb
 echo "
@@ -269,13 +266,33 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
       "files": {
         "collect_list": [
           {
-            "file_path": "/home/ec2-user/.pm2/logs/eAPD-API-error-0.log*",
-            "log_group_name": "preview/home/ec2-user/.pm2/logs/eAPD-API-error-0.log"
+            "file_path": "/app/api/logs/eAPD-API-error-0.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-error-0.log"
           },
           {
-            "file_path": "/home/ec2-user/.pm2/logs/eAPD-API-out-0.log*",
-            "log_group_name": "preview/home/ec2-user/.pm2/logs/eAPD-API-out-0.log"
-          }
+            "file_path": "/app/api/logs/eAPD-API-out-0.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-out-0.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-migration-error.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-error.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-migration-out.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-out.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-seeding-error.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-error.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-seeding-out.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-out.log"
+          },                                        
+          {
+            "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/cms-hitech-apd-api.logs"              
+          }    
         ]
       }
     }
@@ -351,6 +368,8 @@ echo "module.exports = {
     script: 'main.js',
     instances: 1,
     autorestart: true,
+    error_file: "/app/api/logs/eAPD-API-error-0.log",
+    out_file: "/app/api/logs/eAPD-API-out-0.log",
     env: {
       AUTH_LOCK_FAILED_ATTEMPTS_COUNT: 15,
       AUTH_LOCK_FAILED_ATTEMPTS_WINDOW_TIME_MINUTES: 1,

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -8,6 +8,13 @@ mkdir /app
 mkdir /app/api
 mkdir /app/web
 mkdir -p /app/api/logs
+touch /app/api/logs/eAPD-API-error-0.log
+touch /app/api/logs/eAPD-API-out-0.log
+touch /app/api/logs/Database-migration-error.log
+touch /app/api/logs/Database-migration-out.log
+touch /app/api/logs/Database-seeding-error.log
+touch /app/api/logs/Database-seeding-out.log
+touch /app/api/logs/cms-hitech-apd-api.logs
 
 chown -R :eapd /app
 chmod -R g+w /app

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -376,8 +376,8 @@ echo "module.exports = {
     script: 'main.js',
     instances: 1,
     autorestart: true,
-    error_file: "/app/api/logs/eAPD-API-error-0.log",
-    out_file: "/app/api/logs/eAPD-API-out-0.log",
+    error_file: '/app/api/logs/eAPD-API-error-0.log',
+    out_file: '/app/api/logs/eAPD-API-out-0.log',
     env: {
       AUTH_LOCK_FAILED_ATTEMPTS_COUNT: 15,
       AUTH_LOCK_FAILED_ATTEMPTS_WINDOW_TIME_MINUTES: 1,

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -7,14 +7,6 @@ gpasswd -a ec2-user eapd
 mkdir /app
 mkdir /app/api
 mkdir /app/web
-mkdir -p /app/api/logs
-touch /app/api/logs/eAPD-API-error-0.log
-touch /app/api/logs/eAPD-API-out-0.log
-touch /app/api/logs/Database-migration-error.log
-touch /app/api/logs/Database-migration-out.log
-touch /app/api/logs/Database-seeding-error.log
-touch /app/api/logs/Database-seeding-out.log
-touch /app/api/logs/cms-hitech-apd-api.logs
 
 chown -R :eapd /app
 chmod -R g+w /app
@@ -329,6 +321,15 @@ export OKTA_CLIENT_ID="__OKTA_CLIENT_ID__"
 export OKTA_API_KEY="__OKTA_API_KEY__"
 
 cd ~
+
+mkdir -p /app/api/logs
+touch /app/api/logs/eAPD-API-error-0.log
+touch /app/api/logs/eAPD-API-out-0.log
+touch /app/api/logs/Database-migration-error.log
+touch /app/api/logs/Database-migration-out.log
+touch /app/api/logs/Database-seeding-error.log
+touch /app/api/logs/Database-seeding-out.log
+touch /app/api/logs/cms-hitech-apd-api.logs
 
 # Install nvm.  Do it inside the ec2-user home directory so that user will have
 # access to it forever, just in case we need to get into the machine and

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -268,31 +268,31 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
         "collect_list": [
           {
             "file_path": "/app/api/logs/eAPD-API-error-0.log*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-error-0.log"
+            "log_group_name": "preview/app/api/logs/eAPD-API-error-0.log"
           },
           {
             "file_path": "/app/api/logs/eAPD-API-out-0.log*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-out-0.log"
+            "log_group_name": "preview/app/api/logs/eAPD-API-out-0.log"
           },
           {
             "file_path": "/app/api/logs/Database-migration-error.log*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-error.log"
+            "log_group_name": "preview/app/api/logs/Database-migration-error.log"
           },
           {
             "file_path": "/app/api/logs/Database-migration-out.log*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-out.log"
+            "log_group_name": "preview/app/api/logs/Database-migration-out.log"
           },
           {
             "file_path": "/app/api/logs/Database-seeding-error.log*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-error.log"
+            "log_group_name": "preview/app/api/logs/Database-seeding-error.log"
           },
           {
             "file_path": "/app/api/logs/Database-seeding-out.log*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-out.log"
+            "log_group_name": "preview/app/api/logs/Database-seeding-out.log"
           },                                        
           {
             "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/cms-hitech-apd-api.logs"              
+            "log_group_name": "preview/app/api/logs/cms-hitech-apd-api.logs"              
           }    
         ]
       }

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -125,6 +125,8 @@ function addEcosystemToUserData() {
       script: 'main.js',
       instances: 1,
       autorestart: true,
+      error_file: "/app/api/logs/eAPD-API-error-0.log",
+      out_file: "/app/api/logs/eAPD-API-out-0.log",
       env: {
         AWS_ACCESS_KEY_ID: '$API_AWS_ACCESS_KEY_ID',
         AWS_SECRET_ACCESS_KEY: '$API_AWS_SECRET_ACCESS_KEY',
@@ -149,6 +151,8 @@ function addEcosystemToUserData() {
       script: 'npm',
       args: 'run migrate',
       autorestart: false,
+      error_file: "/app/api/logs/Database-migration-error.log",
+      out_file: "/app/api/logs/Database-migration-out.log",
       env: {
         NODE_ENV: 'production',
         DATABASE_URL: '$API_DATABASE_URL'
@@ -158,6 +162,8 @@ function addEcosystemToUserData() {
       script: 'npm',
       args: 'run seed',
       autorestart: false,
+      error_file: "/app/api/logs/Database-seeding-error.log",
+      out_file: "/app/api/logs/Database-seeding-out.log",
       env: {
         NODE_ENV: 'production',
         DATABASE_URL: '$API_DATABASE_URL'

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -125,8 +125,8 @@ function addEcosystemToUserData() {
       script: 'main.js',
       instances: 1,
       autorestart: true,
-      error_file: "/app/api/logs/eAPD-API-error-0.log",
-      out_file: "/app/api/logs/eAPD-API-out-0.log",
+      error_file: '/app/api/logs/eAPD-API-error-0.log',
+      out_file: '/app/api/logs/eAPD-API-out-0.log',
       env: {
         AWS_ACCESS_KEY_ID: '$API_AWS_ACCESS_KEY_ID',
         AWS_SECRET_ACCESS_KEY: '$API_AWS_SECRET_ACCESS_KEY',
@@ -151,8 +151,8 @@ function addEcosystemToUserData() {
       script: 'npm',
       args: 'run migrate',
       autorestart: false,
-      error_file: "/app/api/logs/Database-migration-error.log",
-      out_file: "/app/api/logs/Database-migration-out.log",
+      error_file: '/app/api/logs/Database-migration-error.log',
+      out_file: '/app/api/logs/Database-migration-out.log',
       env: {
         NODE_ENV: 'production',
         DATABASE_URL: '$API_DATABASE_URL'
@@ -162,8 +162,8 @@ function addEcosystemToUserData() {
       script: 'npm',
       args: 'run seed',
       autorestart: false,
-      error_file: "/app/api/logs/Database-seeding-error.log",
-      out_file: "/app/api/logs/Database-seeding-out.log",
+      error_file: '/app/api/logs/Database-seeding-error.log',
+      out_file: '/app/api/logs/Database-seeding-out.log',
       env: {
         NODE_ENV: 'production',
         DATABASE_URL: '$API_DATABASE_URL'

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -201,7 +201,7 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
           },                                        
           {
             "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
-            "log_group_name": "__ENVIRONMENT__/app/api/logs/cms-hitech-apd-api.logs"              
+            "log_group_name": "__ENVIRONMENT__/api/logs/cms-hitech-apd-api.logs"              
           }    
         ]
       }

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -4,7 +4,7 @@
 # directory, then give the directory group write permission
 groupadd eapd
 gpasswd -a ec2-user eapd
-mkdir /app
+mkdir -p /app/api/logs
 chown -R :eapd /app
 chmod g+w /app
 

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -182,6 +182,10 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
             "file_path": "/app/api/logs/eAPD-API-out-0.log*",
             "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-out-0.log"
           },
+         {
+            "file_path": "/app/api/logs/eAPD-API-*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-combined-0.log"
+          },          
           {
             "file_path": "/app/api/logs/Database-migration-error.log*",
             "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-error.log"
@@ -191,13 +195,21 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
             "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-out.log"
           },
           {
+            "file_path": "/app/api/logs/Database-migration-*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-combined.log"
+          },          
+          {
             "file_path": "/app/api/logs/Database-seeding-error.log*",
             "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-error.log"
           },
           {
             "file_path": "/app/api/logs/Database-seeding-out.log*",
             "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-out.log"
-          },                                        
+          },
+          {
+            "file_path": "/app/api/logs/Database-seeding-*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-combined.log"
+          },                                            
           {
             "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
             "log_group_name": "__ENVIRONMENT__/app/api/logs/cms-hitech-apd-api.logs"              

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -11,9 +11,6 @@ chmod g+w /app
 # Oddly, EC2 images don't have git installed. Shruggy person.
 yum -y install git
 
-# Add the Splunk user to the ec2-user group so that it can read logs in /home/ec2-user
-usermod -a -G ec2-user splunk
-
 #Install CloudWatch Agent
 wget https://s3.amazonaws.com/amazoncloudwatch-agent/redhat/amd64/latest/amazon-cloudwatch-agent.rpm
 
@@ -179,12 +176,32 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
       "files": {
         "collect_list": [
           {
-            "file_path": "/home/ec2-user/.pm2/logs/*",
-            "log_group_name": "__ENVIRONMENT__/home/ec2-user/.pm2/logs"
+            "file_path": "/app/api/logs/eAPD-API-error-0.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-error-0.log"
           },
           {
-            "file_path": "/home/ec2-user/.npm/_logs/*",
-            "log_group_name": "__ENVIRONMENT__/home/ec2-user/.npm/_logs"              
+            "file_path": "/app/api/logs/eAPD-API-out-0.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/eAPD-API-out-0.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-migration-error.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-error.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-migration-out.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-migration-out.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-seeding-error.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-error.log"
+          },
+          {
+            "file_path": "/app/api/logs/Database-seeding-out.log*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/Database-seeding-out.log"
+          },                                        
+          {
+            "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/cms-hitech-apd-api.logs"              
           }    
         ]
       }

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -4,14 +4,6 @@
 # directory, then give the directory group write permission
 groupadd eapd
 gpasswd -a ec2-user eapd
-mkdir -p /app/api/logs
-touch /app/api/logs/eAPD-API-error-0.log
-touch /app/api/logs/eAPD-API-out-0.log
-touch /app/api/logs/Database-migration-error.log
-touch /app/api/logs/Database-migration-out.log
-touch /app/api/logs/Database-seeding-error.log
-touch /app/api/logs/Database-seeding-out.log
-touch /app/api/logs/cms-hitech-apd-api.logs
 chown -R :eapd /app
 chmod g+w /app
 
@@ -233,6 +225,15 @@ su ec2-user <<E_USER
 # The su block begins inside the root user's home directory.  Switch to the
 # ec2-user home directory.
 cd ~
+
+mkdir -p /app/api/logs
+touch /app/api/logs/eAPD-API-error-0.log
+touch /app/api/logs/eAPD-API-out-0.log
+touch /app/api/logs/Database-migration-error.log
+touch /app/api/logs/Database-migration-out.log
+touch /app/api/logs/Database-seeding-error.log
+touch /app/api/logs/Database-seeding-out.log
+touch /app/api/logs/cms-hitech-apd-api.logs
 
 # Install nvm.  Do it inside the ec2-user home directory so that user will have
 # access to it forever, just in case we need to get into the machine and

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -201,7 +201,7 @@ cat <<CWAPPLOGCONFIG > /opt/aws/amazon-cloudwatch-agent/doc/app-logs.json
           },                                        
           {
             "file_path": "/app/api/logs/cms-hitech-apd-api.logs*",
-            "log_group_name": "__ENVIRONMENT__/api/logs/cms-hitech-apd-api.logs"              
+            "log_group_name": "__ENVIRONMENT__/app/api/logs/cms-hitech-apd-api.logs"              
           }    
         ]
       }

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -5,6 +5,13 @@
 groupadd eapd
 gpasswd -a ec2-user eapd
 mkdir -p /app/api/logs
+touch /app/api/logs/eAPD-API-error-0.log
+touch /app/api/logs/eAPD-API-out-0.log
+touch /app/api/logs/Database-migration-error.log
+touch /app/api/logs/Database-migration-out.log
+touch /app/api/logs/Database-seeding-error.log
+touch /app/api/logs/Database-seeding-out.log
+touch /app/api/logs/cms-hitech-apd-api.logs
 chown -R :eapd /app
 chmod g+w /app
 


### PR DESCRIPTION
In this PR:
I removed the splunk user being added to the ec2-user group, that did not work to grant Splunk access to /home/ec2-user. 
Added a path for the cms-hitech-apd-api.logs so that it is created in /app/api/logs/cms-hitech-apd-api.logs
Moved pm2 logs from /home/ec2-user/.pm2/logs directory to /app/api/logs
Updated CloudWatch to reflect the new log locations

### This pull request changes...

- splunk user can access /app/apli/logs
- splunk user can not access /home/ec2-user/
- CloudWatch pulls from new log locations

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
