### PR TITLE
Tbolt/2525 add activity button bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Anticipated release: January 25, 2021
 
 
 #### 🐛 Bugs fixed
+- Fixes issue where "Add another activity" button was not appearing as it should ([#2525])
 
 
 #### ⚙️ Behind the scenes
@@ -17,4 +18,5 @@ Anticipated release: January 25, 2021
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
+[#2525]: https://github.com/CMSgov/eAPD/issues/2525
 [#2776]: https://github.com/CMSgov/eAPD/issues/2776

--- a/web/src/components/SecondaryNav.js
+++ b/web/src/components/SecondaryNav.js
@@ -12,7 +12,8 @@ import { addActivity as actualAddActivity } from '../actions/editActivity';
 const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
   const { activityIndex } = useParams();
   const showAddActivityLink =
-    Number(activityIndex) + 1 === activityCount && location.pathname.endsWith('ffp');
+    Number(activityIndex) + 1 === activityCount &&
+    location.pathname.endsWith('ffp');
 
   return (
     <Fragment>

--- a/web/src/components/SecondaryNav.js
+++ b/web/src/components/SecondaryNav.js
@@ -12,7 +12,7 @@ import { addActivity as actualAddActivity } from '../actions/editActivity';
 const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
   const { activityIndex } = useParams();
   const showAddActivityLink =
-    activityIndex + 1 === activityCount && location.pathname.endsWith('ffp');
+    Number(activityIndex) + 1 === activityCount && location.pathname.endsWith('ffp');
 
   return (
     <Fragment>

--- a/web/src/components/SecondaryNav.test.js
+++ b/web/src/components/SecondaryNav.test.js
@@ -11,7 +11,7 @@ const defaultProps = {
   activityCount: 2,
   addActivity: jest.fn(),
   location: { pathname: '/apd/activity/1/ffp' },
-  useParams: () => ({ activityIndex: "1" })
+  useParams: () => ({ activityIndex: '1' })
 };
 
 const setup = (props = {}) => {
@@ -21,13 +21,12 @@ const setup = (props = {}) => {
 describe('Secondary Nav component', () => {
   it('renders with add activity button when on the last activity on the FFP section', () => {
     const component = setup();
-    console.log(component.debug());
     expect(component.find('Link').exists()).toBe(true);
   });
 
   it('renders without add activity button when not on the last activity', () => {
     const component = setup({
-      useParams: () => ({ activityIndex: "0" })
+      useParams: () => ({ activityIndex: '0' })
     });
     expect(component.find('Link').exists()).toBe(false);
   });

--- a/web/src/components/SecondaryNav.test.js
+++ b/web/src/components/SecondaryNav.test.js
@@ -11,7 +11,7 @@ const defaultProps = {
   activityCount: 2,
   addActivity: jest.fn(),
   location: { pathname: '/apd/activity/1/ffp' },
-  useParams: () => ({ activityIndex: 1 })
+  useParams: () => ({ activityIndex: "1" })
 };
 
 const setup = (props = {}) => {
@@ -21,12 +21,13 @@ const setup = (props = {}) => {
 describe('Secondary Nav component', () => {
   it('renders with add activity button when on the last activity on the FFP section', () => {
     const component = setup();
+    console.log(component.debug());
     expect(component.find('Link').exists()).toBe(true);
   });
 
   it('renders without add activity button when not on the last activity', () => {
     const component = setup({
-      useParams: () => ({ activityIndex: 0 })
+      useParams: () => ({ activityIndex: "0" })
     });
     expect(component.find('Link').exists()).toBe(false);
   });

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -35,7 +35,9 @@ const ApdSummary = ({
     const year = e.target.value;
 
     if (e.target.checked === false) {
-      const confirmation = window.confirm(`Unchecking Federal Fiscal Year ${year} will permanently delete any FFY ${year} specific data in the current APD.`); // eslint-disable-line no-alert
+      const confirmation = window.confirm(
+        `Unchecking Federal Fiscal Year ${year} will permanently delete any FFY ${year} specific data in the current APD.`
+      ); // eslint-disable-line no-alert
       if (confirmation === true) {
         removeApdYear(year);
       } else {

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -125,7 +125,10 @@ const StateDashboard = (
             <UpgradeBrowser />
             <div className="ds-l-row ds-u-margin-top--7">
               <div className="ds-l-col--8 ds-u-margin-x--auto">
-                <div className="ds-u-display--flex ds-u-justify-content--center" data-testid="eAPDlogo">
+                <div
+                  className="ds-u-display--flex ds-u-justify-content--center"
+                  data-testid="eAPDlogo"
+                >
                   <img
                     src="/static/img/eAPDLogoSVG:ICO/SVG/eAPDColVarSVG.svg"
                     alt="eAPD Logo"

--- a/web/src/containers/activity/All.test.js
+++ b/web/src/containers/activity/All.test.js
@@ -18,7 +18,7 @@ const initialProps = {
   ]
 };
 
-const setup = (props) => shallow(<Activities {...initialProps} {...props} />);
+const setup = props => shallow(<Activities {...initialProps} {...props} />);
 
 describe('the Activities component', () => {
   it('renders correctly', () => {

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -315,7 +315,7 @@ describe('APD reducer', () => {
             costAllocationNarrative: {
               '1741': { otherSources: '' },
               '1742': { otherSources: '' },
-              'methodology': ''
+              methodology: ''
             },
             contractorResources: [
               {
@@ -399,7 +399,7 @@ describe('APD reducer', () => {
             costAllocationNarrative: {
               '1741': { otherSources: '' },
               '1742': { otherSources: '' },
-              'methodology': ''
+              methodology: ''
             },
             contractorResources: [
               {
@@ -517,7 +517,7 @@ describe('APD reducer', () => {
             costAllocationNarrative: {
               '1741': { otherSources: '' },
               '1742': { otherSources: '' },
-              'methodology': ''
+              methodology: ''
             },
             contractorResources: [
               {
@@ -631,7 +631,7 @@ describe('APD reducer', () => {
             },
             costAllocationNarrative: {
               '1742': { otherSources: '' },
-              'methodology': ''
+              methodology: ''
             },
             contractorResources: [
               {


### PR DESCRIPTION
Resolves #2525 

### This pull request changes...

- Fixes the type issue that caused the **Add another activity** button to not show when it should

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
