### PR TITLE
Refactor StateDashboard Component

### DIFF
--- a/web/src/components/ApdList.js
+++ b/web/src/components/ApdList.js
@@ -1,0 +1,180 @@
+import { Button } from '@cmsgov/design-system';
+import PropType from 'prop-types';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+
+import Icon, { File, faPlusCircle, faSpinner } from "./Icons";
+import Instruction from "./Instruction";
+import { createApd, deleteApd, selectApd } from '../actions/app';
+import { t } from '../i18n';
+import { selectApdDashboard, selectApds } from '../reducers/apd.selectors';
+import UpgradeBrowser from "./UpgradeBrowser";
+
+const Loading = ({ children }) => (
+  <div className="ds-h2 ds-u-margin-top--7 ds-u-padding--0 ds-u-padding-bottom--3 ds-u-text-align--center">
+    <Icon icon={faSpinner} spin size="sm" className="ds-u-margin-right--1" />{' '}
+    {children}
+  </div>
+);
+Loading.propTypes = { children: PropType.node.isRequired };
+
+const ApdList = (
+  {
+    apds,
+    createApd: create,
+    deleteApd: del,
+    fetching,
+    route,
+    selectApd: select,
+    state,
+  },
+  { global = window } = {}
+) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const createNew = () => {
+    setIsLoading(true);
+    create();
+  };
+
+  const open = id => e => {
+    setIsLoading(true);
+    e.preventDefault();
+    select(id, route);
+  };
+
+  const delApd = apd => () => {
+    if (apd && global.confirm(`Delete ${apd.name}?`)) {
+      del(apd.id);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div id="start-main-content">
+        <Loading>Loading your APD</Loading>
+      </div>
+    );
+  }
+
+  return (
+    <div className="site-body ds-l-container">
+      <div className="ds-u-margin--0">
+        <main id="start-main-content">
+          <div className="ds-u-padding-top--2">
+            <UpgradeBrowser />
+            <div className="ds-l-row ds-u-margin-top--7">
+              <div className="ds-l-col--8 ds-u-margin-x--auto">
+                <div
+                  className="ds-u-display--flex ds-u-justify-content--center"
+                  data-testid="eAPDlogo"
+                >
+                  <img
+                    src="/static/img/eAPDLogoSVG:ICO/SVG/eAPDColVarSVG.svg"
+                    alt="eAPD Logo"
+                  />
+                </div>
+                <Instruction source="stateDashboard.introduction" />
+                <div className="ds-u-margin-top--5 ds-u-padding-bottom--1 ds-u-border-bottom--2">
+                  <h2 className="ds-h2 ds-u-display--inline-block">
+                    {state ? state.name : ''} APDs
+                  </h2>
+                  <Button
+                    variation="primary"
+                    className="ds-u-float--right"
+                    onClick={createNew}
+                  >
+                    Create new{' '}
+                    <span className="ds-u-visibility--screen-reader">
+                      APD
+                    </span>
+                    &nbsp;&nbsp;
+                    <Icon icon={faPlusCircle} />
+                  </Button>
+                </div>
+              </div>
+            </div>
+            {fetching ? <Loading>Loading APDs</Loading> : null}
+            {!fetching && apds.length === 0 ? (
+              <div className="ds-l-row">
+                <div className="ds-l-col--8 ds-u-margin-x--auto ds-u-padding-top--2 ds-u-padding-bottom--5 ds-u-color--muted">
+                  {t('stateDashboard.none')}
+                </div>
+              </div>
+            ) : null}
+            {apds.map(apd => (
+              <div key={apd.id} className="ds-l-row">
+                <div className="ds-l-col--8 ds-u-margin-x--auto ds-u-padding-top--2">
+                  <div className="ds-u-border-bottom--2 ds-u-padding-bottom--3">
+                    <div className="ds-u-display--inline-block ds-u-float--left ds-u-fill--primary-alt-lightest ds-u-padding--2 ds-u-margin-right--2">
+                      <File size="lg" color="#046b99" />
+                    </div>
+                    <div className="ds-u-display--inline-block">
+                      <h3 className="ds-u-margin-y--0">
+                        <a href="#!" onClick={open(apd.id)}>
+                          <span className="ds-u-visibility--screen-reader">
+                            Edit APD:{' '}
+                          </span>
+                          {apd.name}
+                        </a>
+                      </h3>
+                      <ul className="ds-c-list--bare">
+                        <li>
+                          <strong>Last edited:</strong> {apd.updated}
+                        </li>
+                        <li>
+                          <strong>Created:</strong> {apd.created}
+                        </li>
+                      </ul>
+                    </div>
+                    <div className="ds-u-display--inline-block ds-u-float--right ds-u-text-align--right">
+                      <Button
+                        variation="transparent"
+                        size="small"
+                        onClick={delApd(apd)}
+                      >
+                        Delete{' '}
+                        <span className="ds-u-visibility--screen-reader">
+                          {' '}
+                          this APD
+                        </span>
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+ApdList.propTypes = {
+  apds: PropType.array.isRequired,
+  fetching: PropType.bool.isRequired,
+  route: PropType.string,
+  state: PropType.object.isRequired,
+  createApd: PropType.func.isRequired,
+  deleteApd: PropType.func.isRequired,
+  selectApd: PropType.func.isRequired,
+};
+
+ApdList.defaultProps = {
+  route: '/apd',
+};
+
+const mapStateToProps = state => ({
+  apds: selectApdDashboard(state),
+  fetching: selectApds(state).fetching,
+  state: state.user.data.state || null,
+});
+
+const mapDispatchToProps = {
+  createApd,
+  deleteApd,
+  selectApd
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ApdList);

--- a/web/src/components/ApdList.test.js
+++ b/web/src/components/ApdList.test.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import ApdList from './ApdList';
+import { renderWithConnection } from '../shared/apd-testing-library';
+import mockAxios from '../util/api';
+import { STATE_AFFILIATION_STATUSES } from '../constants';
+
+jest.mock('../util/api', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn()
+}));
+
+let props;
+let renderUtils;
+
+const apd = {
+  id: '1',
+  name: 'Sample APD',
+  updated: '2020-07-27 17:50:02.834242+00',
+  created: '2020-07-28 20:20:56.835976+00',
+  state: 'MO',
+  status: 'draft'
+};
+const createdStr = 'July 27, 2020';
+const updatedStr = 'July 28, 2020, 3:20 PM EDT';
+
+describe('<ApdList />', () => {
+  beforeEach(() => {
+    props = {
+      apds: [],
+      fetching: false,
+      createApd: jest.fn(),
+      deleteApd: jest.fn(),
+      selectApd: jest.fn(),
+      route: '/apd'
+    };
+  });
+
+  describe('no apds', () => {
+    beforeEach(() => {
+      mockAxios.get.mockImplementation(() => Promise.resolve({ data: [] }));
+      renderUtils = renderWithConnection(
+        <ApdList {...props} pending={false} />,
+        {
+          initialState: {
+            user: {
+              data: {
+                state: { id: 'mo' },
+                affiliations: [
+                  {
+                    state_id: 'mo',
+                    status: STATE_AFFILIATION_STATUSES.APPROVED
+                  }
+                ]
+              }
+            }
+          }
+        }
+      );
+    });
+
+    it('should display the introduction and instructions', () => {
+      const { queryByText } = renderUtils;
+      expect(
+        queryByText(
+          /The CMS HITECH APD app is the new way to create and manage/i
+        )
+      ).toBeTruthy();
+      expect(queryByText(/All your state's APDs are listed here./i)).toBeNull();
+    });
+
+    it('should handle clicking the create APD button', async () => {
+      mockAxios.post.mockImplementation(() => Promise.resolve({ data: apd }));
+      const { queryByRole } = renderUtils;
+      expect(queryByRole('button', { name: /Create new/i })).toBeTruthy();
+      // fireEvent.click(queryByRole('button', { name: /Create new/i }));
+      // expect(props.createApd).toHaveBeenCalled();
+    });
+
+    it('should display the empty APD message', () => {
+      const { queryByText } = renderUtils;
+      expect(queryByText(/You have not created any APDs./i)).toBeTruthy();
+    });
+
+    it("shouldn't display the pending message", () => {
+      const { queryByAltText, queryByText } = renderUtils;
+      expect(queryByAltText(/Puzzle Piece Icon/i)).toBeNull();
+      expect(
+        queryByText(/Approval Pending From State Administrator/i)
+      ).toBeNull();
+    });
+  });
+
+  describe('default state with apds', () => {
+    beforeEach(() => {
+      mockAxios.get.mockImplementation(() => Promise.resolve({ data: [apd] }));
+      renderUtils = renderWithConnection(
+        <ApdList {...props} pending={false} />,
+        {
+          initialState: {
+            user: {
+              data: {
+                state: { id: 'mo' },
+                affiliations: [
+                  {
+                    state_id: 'mo',
+                    status: STATE_AFFILIATION_STATUSES.APPROVED
+                  }
+                ]
+              }
+            },
+            apd: {
+              byId: {
+                [apd.id]: {
+                  ...apd,
+                  created: createdStr,
+                  updated: updatedStr
+                }
+              }
+            }
+          }
+        }
+      );
+    });
+
+    it('should display the APD', () => {
+      const { getByText } = renderUtils;
+      expect(getByText(apd.name)).toBeTruthy();
+      expect(getByText(updatedStr)).toBeTruthy();
+      expect(getByText(createdStr)).toBeTruthy();
+    });
+
+    it('should allow the user to click on the APD to edit', () => {
+      const { getByText } = renderUtils;
+      expect(getByText(apd.name)).toBeTruthy();
+      // fireEvent.click(getByText(apd.name));
+      // expect(props.selectApd).toHaveBeenCalledWith(apd.id, props.route);
+    });
+
+    it('should allow the user to click the delete APD button', () => {
+      const { getByText } = renderUtils;
+      expect(getByText(/Delete/i)).toBeTruthy();
+      // fireEvent.click(getByText(/Delete/i));
+      // expect(props.deleteApd).toHaveBeenCalledWith(apd);
+    });
+  });
+});

--- a/web/src/components/StateAffiliationStatus.js
+++ b/web/src/components/StateAffiliationStatus.js
@@ -1,0 +1,116 @@
+import PropType from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import Instruction from "./Instruction";
+import { getUserStateOrTerritoryStatus } from '../reducers/user.selector';
+import { STATE_AFFILIATION_STATUSES } from '../constants';
+import UpgradeBrowser from "./UpgradeBrowser";
+
+const PendingApproval = () => (
+  <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
+    <img alt="Puzzle Piece Icon" src="../static/icons/puzzle.svg" width="57" />
+    <h3 className="ds-u-margin-bottom--1">
+      Approval Pending From State Administrator
+    </h3>
+    <p className="ds-u-margin--0">
+      Please contact State Administrator for more information.
+    </p>
+  </div>
+);
+
+const ApprovalDenied = () => (
+  <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
+    <img alt="Puzzle Piece Icon" src="../static/icons/alert.svg" height="51" />
+    <h3 className="ds-u-margin-bottom--1">Approval Has Been Denied</h3>
+    <p className="ds-u-margin--0">
+      Please contact State Administrator for more information.
+    </p>
+  </div>
+);
+
+const ApprovalRevoked = () => (
+  <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
+    <img alt="Puzzle Piece Icon" src="../static/icons/alert.svg" height="51" />
+    <h3 className="ds-u-margin-bottom--1">Approval Permissions Revoked</h3>
+    <p className="ds-u-margin--0">
+      Please contact State Administrator for more information.
+    </p>
+  </div>
+);
+
+// TODO: We'll have to figure out a way to only show this the first time they go into an approved state?
+// const Approved = () => (
+//   <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
+//     <img
+//       alt="Puzzle Piece Icon"
+//       src="../static/icons/thumbs-up.svg"
+//       width="57"
+//     />
+//     <h3 className="ds-u-margin-bottom--1">Approved</h3>
+//     <p className="ds-u-margin--0">
+//       Congratulations! You may now create an APD.
+//     </p>
+//   </div>
+// );
+
+const StateAffiliationStatus = (
+  {
+    state,
+    stateStatus
+  }
+) => {
+
+  return (
+    <div className="site-body ds-l-container">
+      <div className="ds-u-margin--0">
+        <main id="start-main-content">
+          <div className="ds-u-padding-top--2">
+            <UpgradeBrowser />
+            <div className="ds-l-row ds-u-margin-top--7">
+              <div className="ds-l-col--8 ds-u-margin-x--auto">
+                <div
+                  className="ds-u-display--flex ds-u-justify-content--center"
+                  data-testid="eAPDlogo"
+                >
+                  <img
+                    src="/static/img/eAPDLogoSVG:ICO/SVG/eAPDColVarSVG.svg"
+                    alt="eAPD Logo"
+                  />
+                </div>
+                <Instruction source="stateDashboard.introduction" />
+                <div className="ds-u-margin-top--5 ds-u-padding-bottom--1 ds-u-border-bottom--2">
+                  <h2 className="ds-h2 ds-u-display--inline-block">
+                    {state ? state.name : ''} APDs
+                  </h2>
+                </div>
+              </div>
+            </div>
+            {stateStatus === STATE_AFFILIATION_STATUSES.REQUESTED ? (
+              <PendingApproval />
+            ) : null}
+            {stateStatus === STATE_AFFILIATION_STATUSES.DENIED ? (
+              <ApprovalDenied />
+            ) : null}
+            {stateStatus === STATE_AFFILIATION_STATUSES.REVOKED ? (
+              <ApprovalRevoked />
+            ) : null}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+StateAffiliationStatus.propTypes = {
+  state: PropType.object.isRequired,
+  stateStatus: PropType.string.isRequired
+};
+
+const mapStateToProps = state => ({
+  state: state.user.data.state || null,
+  stateStatus:
+    getUserStateOrTerritoryStatus(state) || STATE_AFFILIATION_STATUSES.REQUESTED
+});
+
+export default connect(mapStateToProps)(StateAffiliationStatus);

--- a/web/src/components/StateAffiliationStatus.test.js
+++ b/web/src/components/StateAffiliationStatus.test.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import StateAffiliationStatus from './StateAffiliationStatus';
+import { renderWithConnection } from '../shared/apd-testing-library';
+import { STATE_AFFILIATION_STATUSES } from '../constants';
+
+jest.mock('../util/api', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  delete: jest.fn()
+}));
+
+let props;
+let renderUtils;
+
+describe('<StateAffiliationStatus />', () => {
+  beforeEach(() => {
+    props = {
+      apds: [],
+      fetching: false,
+      createApd: jest.fn(),
+      deleteApd: jest.fn(),
+      selectApd: jest.fn(),
+      route: '/apd'
+    };
+  });
+  describe('pending state', () => {
+    beforeEach(() => {
+      renderUtils = renderWithConnection(<StateAffiliationStatus {...props} />, {
+        initialState: {
+          user: {
+            data: {
+              state: { id: 'mo' },
+              affiliations: [
+                { state_id: 'mo', status: STATE_AFFILIATION_STATUSES.REQUESTED }
+              ]
+            }
+          }
+        }
+      });
+    });
+
+    it('should display the eAPD Logo', () => {
+      const { getByTestId } = renderUtils;
+      expect(getByTestId('eAPDlogo')).toBeTruthy();
+    });
+
+    it('should display introduction', () => {
+      const { queryByText } = renderUtils;
+      expect(
+        queryByText(
+          /The CMS HITECH APD app is the new way to create and manage/i
+        )
+      ).toBeTruthy();
+    });
+
+    it('should display the pending message', () => {
+      const { getByAltText, getByText } = renderUtils;
+      expect(getByAltText(/Puzzle Piece Icon/i)).toBeTruthy();
+      expect(
+        getByText(/Approval Pending From State Administrator/i)
+      ).toBeTruthy();
+    });
+  });
+
+  describe('denied state', () => {
+    beforeEach(() => {
+      renderUtils = renderWithConnection(<StateAffiliationStatus {...props} />, {
+        initialState: {
+          user: {
+            data: {
+              state: { id: 'mo' },
+              affiliations: [
+                { state_id: 'mo', status: STATE_AFFILIATION_STATUSES.DENIED }
+              ]
+            }
+          }
+        }
+      });
+    });
+
+    it('should display the denied message', () => {
+      const { getByAltText, getByText } = renderUtils;
+      expect(getByAltText(/Puzzle Piece Icon/i)).toBeTruthy();
+      expect(getByText(/Approval Has Been Denied/i)).toBeTruthy();
+    });
+  });
+
+  describe('revoked state', () => {
+    beforeEach(() => {
+      renderUtils = renderWithConnection(<StateAffiliationStatus {...props} />, {
+        initialState: {
+          user: {
+            data: {
+              state: { id: 'mo' },
+              affiliations: [
+                { state_id: 'mo', status: STATE_AFFILIATION_STATUSES.REVOKED }
+              ]
+            }
+          }
+        }
+      });
+    });
+
+    it('should display the revoked message', () => {
+      const { getByAltText, getByText } = renderUtils;
+      expect(getByAltText(/Puzzle Piece Icon/i)).toBeTruthy();
+      expect(getByText(/Approval Permissions Revoked/i)).toBeTruthy();
+    });
+  });
+
+});

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -1,88 +1,20 @@
-import { Button } from '@cmsgov/design-system';
 import PropType from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import TagManager from 'react-gtm-module';
 
-import Icon, { File, faPlusCircle, faSpinner } from '../components/Icons';
-import Instruction from '../components/Instruction';
-import { createApd, deleteApd, selectApd } from '../actions/app';
-import { t } from '../i18n';
-import { selectApdDashboard, selectApds } from '../reducers/apd.selectors';
+import ApdList from '../components/ApdList';
+import StateAffiliationStatus from '../components/StateAffiliationStatus';
 import { getUserStateOrTerritoryStatus } from '../reducers/user.selector';
 import { STATE_AFFILIATION_STATUSES } from '../constants';
-import UpgradeBrowser from '../components/UpgradeBrowser';
-
-const Loading = ({ children }) => (
-  <div className="ds-h2 ds-u-margin-top--7 ds-u-padding--0 ds-u-padding-bottom--3 ds-u-text-align--center">
-    <Icon icon={faSpinner} spin size="sm" className="ds-u-margin-right--1" />{' '}
-    {children}
-  </div>
-);
-Loading.propTypes = { children: PropType.node.isRequired };
-
-const PendingApproval = () => (
-  <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
-    <img alt="Puzzle Piece Icon" src="../static/icons/puzzle.svg" width="57" />
-    <h3 className="ds-u-margin-bottom--1">
-      Approval Pending From State Administrator
-    </h3>
-    <p className="ds-u-margin--0">
-      Please contact State Administrator for more information.
-    </p>
-  </div>
-);
-
-const ApprovalDenied = () => (
-  <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
-    <img alt="Puzzle Piece Icon" src="../static/icons/alert.svg" height="51" />
-    <h3 className="ds-u-margin-bottom--1">Approval Has Been Denied</h3>
-    <p className="ds-u-margin--0">
-      Please contact State Administrator for more information.
-    </p>
-  </div>
-);
-
-const ApprovalRevoked = () => (
-  <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
-    <img alt="Puzzle Piece Icon" src="../static/icons/alert.svg" height="51" />
-    <h3 className="ds-u-margin-bottom--1">Approval Permissions Revoked</h3>
-    <p className="ds-u-margin--0">
-      Please contact State Administrator for more information.
-    </p>
-  </div>
-);
-
-// TODO: We'll have to figure out a way to only show this the first time they go into an approved state?
-// const Approved = () => (
-//   <div className="ds-u-display--flex ds-u-flex-direction--column ds-u-justify-content--center ds-u-align-items--center ds-u-margin-y--4">
-//     <img
-//       alt="Puzzle Piece Icon"
-//       src="../static/icons/thumbs-up.svg"
-//       width="57"
-//     />
-//     <h3 className="ds-u-margin-bottom--1">Approved</h3>
-//     <p className="ds-u-margin--0">
-//       Congratulations! You may now create an APD.
-//     </p>
-//   </div>
-// );
 
 const StateDashboard = (
   {
-    apds,
-    createApd: create,
-    deleteApd: del,
-    fetching,
-    route,
-    selectApd: select,
     state,
     role,
     stateStatus
-  },
-  { global = window } = {}
+  }
 ) => {
-  const [isLoading, setIsLoading] = useState(false);
   TagManager.dataLayer({
     dataLayer: {
       stateId: state ? state.id : null,
@@ -90,171 +22,29 @@ const StateDashboard = (
     }
   });
 
-  const createNew = () => {
-    setIsLoading(true);
-    create();
-  };
-
-  const open = id => e => {
-    setIsLoading(true);
-    e.preventDefault();
-    select(id, route);
-  };
-
-  const delApd = apd => () => {
-    if (apd && global.confirm(`Delete ${apd.name}?`)) {
-      del(apd.id);
-    }
-  };
-
-  if (isLoading) {
-    return (
-      <div id="start-main-content">
-        <Loading>Loading your APD</Loading>
-      </div>
-    );
-  }
+  const isApproved = stateStatus === STATE_AFFILIATION_STATUSES.APPROVED;
 
   return (
-    <div className="site-body ds-l-container">
-      <div className="ds-u-margin--0">
-        <main id="start-main-content">
-          <div className="ds-u-padding-top--2">
-            <UpgradeBrowser />
-            <div className="ds-l-row ds-u-margin-top--7">
-              <div className="ds-l-col--8 ds-u-margin-x--auto">
-                <div
-                  className="ds-u-display--flex ds-u-justify-content--center"
-                  data-testid="eAPDlogo"
-                >
-                  <img
-                    src="/static/img/eAPDLogoSVG:ICO/SVG/eAPDColVarSVG.svg"
-                    alt="eAPD Logo"
-                  />
-                </div>
-                <Instruction source="stateDashboard.introduction" />
-                {stateStatus === STATE_AFFILIATION_STATUSES.APPROVED && (
-                  <Instruction source="stateDashboard.instruction" />
-                )}
-                <div className="ds-u-margin-top--5 ds-u-padding-bottom--1 ds-u-border-bottom--2">
-                  <h2 className="ds-h2 ds-u-display--inline-block">
-                    {state ? state.name : ''} APDs
-                  </h2>
-                  {stateStatus === STATE_AFFILIATION_STATUSES.APPROVED && (
-                    <Button
-                      variation="primary"
-                      className="ds-u-float--right"
-                      onClick={createNew}
-                    >
-                      Create new{' '}
-                      <span className="ds-u-visibility--screen-reader">
-                        APD
-                      </span>
-                      &nbsp;&nbsp;
-                      <Icon icon={faPlusCircle} />
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-            {stateStatus === STATE_AFFILIATION_STATUSES.REQUESTED ? (
-              <PendingApproval />
-            ) : null}
-            {stateStatus === STATE_AFFILIATION_STATUSES.DENIED ? (
-              <ApprovalDenied />
-            ) : null}
-            {stateStatus === STATE_AFFILIATION_STATUSES.REVOKED ? (
-              <ApprovalRevoked />
-            ) : null}
-            {fetching ? <Loading>Loading APDs</Loading> : null}
-            {!fetching &&
-            stateStatus === STATE_AFFILIATION_STATUSES.APPROVED &&
-            apds.length === 0 ? (
-              <div className="ds-l-row">
-                <div className="ds-l-col--8 ds-u-margin-x--auto ds-u-padding-top--2 ds-u-padding-bottom--5 ds-u-color--muted">
-                  {t('stateDashboard.none')}
-                </div>
-              </div>
-            ) : null}
-            {stateStatus === STATE_AFFILIATION_STATUSES.APPROVED &&
-              apds.map(apd => (
-                <div key={apd.id} className="ds-l-row">
-                  <div className="ds-l-col--8 ds-u-margin-x--auto ds-u-padding-top--2">
-                    <div className="ds-u-border-bottom--2 ds-u-padding-bottom--3">
-                      <div className="ds-u-display--inline-block ds-u-float--left ds-u-fill--primary-alt-lightest ds-u-padding--2 ds-u-margin-right--2">
-                        <File size="lg" color="#046b99" />
-                      </div>
-                      <div className="ds-u-display--inline-block">
-                        <h3 className="ds-u-margin-y--0">
-                          <a href="#!" onClick={open(apd.id)}>
-                            <span className="ds-u-visibility--screen-reader">
-                              Edit APD:{' '}
-                            </span>
-                            {apd.name}
-                          </a>
-                        </h3>
-                        <ul className="ds-c-list--bare">
-                          <li>
-                            <strong>Last edited:</strong> {apd.updated}
-                          </li>
-                          <li>
-                            <strong>Created:</strong> {apd.created}
-                          </li>
-                        </ul>
-                      </div>
-                      <div className="ds-u-display--inline-block ds-u-float--right ds-u-text-align--right">
-                        <Button
-                          variation="transparent"
-                          size="small"
-                          onClick={delApd(apd)}
-                        >
-                          Delete{' '}
-                          <span className="ds-u-visibility--screen-reader">
-                            {' '}
-                            this APD
-                          </span>
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-          </div>
-        </main>
-      </div>
-    </div>
-  );
+    <React.Fragment>
+      {isApproved && (<ApdList />)}
+      {!isApproved && (<StateAffiliationStatus />)}
+    </React.Fragment>
+  )
 };
 
 StateDashboard.propTypes = {
-  apds: PropType.array.isRequired,
-  fetching: PropType.bool.isRequired,
-  route: PropType.string,
   state: PropType.object.isRequired,
   role: PropType.string.isRequired,
-  createApd: PropType.func.isRequired,
-  deleteApd: PropType.func.isRequired,
-  selectApd: PropType.func.isRequired,
   stateStatus: PropType.string.isRequired
 };
 
-StateDashboard.defaultProps = {
-  route: '/apd'
-};
-
 const mapStateToProps = state => ({
-  apds: selectApdDashboard(state),
-  fetching: selectApds(state).fetching,
   state: state.user.data.state || null,
   role: state.user.data.role || 'Pending Role',
   stateStatus:
     getUserStateOrTerritoryStatus(state) || STATE_AFFILIATION_STATUSES.REQUESTED
 });
 
-const mapDispatchToProps = {
-  createApd,
-  deleteApd,
-  selectApd
-};
+export default connect(mapStateToProps)(StateDashboard);
 
-export default connect(mapStateToProps, mapDispatchToProps)(StateDashboard);
+export { StateDashboard as plain, mapStateToProps };

--- a/web/src/containers/StateDashboard.test.js
+++ b/web/src/containers/StateDashboard.test.js
@@ -1,243 +1,31 @@
+import { shallow } from 'enzyme';
 import React from 'react';
-import StateDashboard from './StateDashboard';
-import { renderWithConnection } from '../shared/apd-testing-library';
-import mockAxios from '../util/api';
 import { STATE_AFFILIATION_STATUSES } from '../constants';
 
-jest.mock('../util/api', () => ({
-  get: jest.fn(),
-  post: jest.fn(),
-  patch: jest.fn(),
-  delete: jest.fn()
-}));
+import ApdList from '../components/ApdList';
+import StateAffiliationStatus from '../components/StateAffiliationStatus';
 
-let props;
-let renderUtils;
+import {
+  plain as StateDashboard,
+} from './StateDashboard';
 
-const apd = {
-  id: '1',
-  name: 'Sample APD',
-  updated: '2020-07-27 17:50:02.834242+00',
-  created: '2020-07-28 20:20:56.835976+00',
-  state: 'MO',
-  status: 'draft'
+const initialProps = {
+  state: { id: 'ak' },
+  role: 'some role',
+  stateStatus: STATE_AFFILIATION_STATUSES.APPROVED
 };
-const createdStr = 'July 27, 2020';
-const updatedStr = 'July 28, 2020, 3:20 PM EDT';
 
-describe('<StateDashboard />', () => {
-  beforeEach(() => {
-    props = {
-      apds: [],
-      fetching: false,
-      createApd: jest.fn(),
-      deleteApd: jest.fn(),
-      selectApd: jest.fn(),
-      route: '/apd'
-    };
-  });
-  describe('pending state', () => {
-    beforeEach(() => {
-      renderUtils = renderWithConnection(<StateDashboard {...props} />, {
-        initialState: {
-          user: {
-            data: {
-              state: { id: 'mo' },
-              affiliations: [
-                { state_id: 'mo', status: STATE_AFFILIATION_STATUSES.REQUESTED }
-              ]
-            }
-          }
-        }
-      });
-    });
+const setup = (props = {}) =>
+  shallow(<StateDashboard {...initialProps} {...props} />);
 
-    it('should display the eAPD Logo', () => {
-      const { getByTestId } = renderUtils;
-      expect(getByTestId('eAPDlogo')).toBeTruthy();
-    });
-
-    it('should display introduction, but not instruction', () => {
-      const { queryByText } = renderUtils;
-      expect(
-        queryByText(
-          /The CMS HITECH APD app is the new way to create and manage/i
-        )
-      ).toBeTruthy();
-      expect(queryByText(/All your state's APDs are listed here./i)).toBeNull();
-    });
-
-    it("shouldn't display the create APD button", () => {
-      const { queryByRole } = renderUtils;
-      expect(queryByRole('button', { name: /create/i })).toBeNull();
-    });
-
-    it("shouldn't display the empty APD message", () => {
-      const { queryByText } = renderUtils;
-      expect(queryByText(/You have not created any APDs./i)).toBeNull();
-    });
-
-    it('should display the pending message', () => {
-      const { getByAltText, getByText } = renderUtils;
-      expect(getByAltText(/Puzzle Piece Icon/i)).toBeTruthy();
-      expect(
-        getByText(/Approval Pending From State Administrator/i)
-      ).toBeTruthy();
-    });
+describe('<StateDashboard /> component', () => {
+  it('renders <ApdList /> when State Affiliation Status is Approved', () => {
+    const component = setup();
+    expect(component.find(ApdList).exists()).toBe(true);
   });
 
-  describe('denied state', () => {
-    beforeEach(() => {
-      renderUtils = renderWithConnection(<StateDashboard {...props} />, {
-        initialState: {
-          user: {
-            data: {
-              state: { id: 'mo' },
-              affiliations: [
-                { state_id: 'mo', status: STATE_AFFILIATION_STATUSES.DENIED }
-              ]
-            }
-          }
-        }
-      });
-    });
-
-    it('should display the denied message', () => {
-      const { getByAltText, getByText } = renderUtils;
-      expect(getByAltText(/Puzzle Piece Icon/i)).toBeTruthy();
-      expect(getByText(/Approval Has Been Denied/i)).toBeTruthy();
-    });
-  });
-
-  describe('revoked state', () => {
-    beforeEach(() => {
-      renderUtils = renderWithConnection(<StateDashboard {...props} />, {
-        initialState: {
-          user: {
-            data: {
-              state: { id: 'mo' },
-              affiliations: [
-                { state_id: 'mo', status: STATE_AFFILIATION_STATUSES.REVOKED }
-              ]
-            }
-          }
-        }
-      });
-    });
-
-    it('should display the revoked message', () => {
-      const { getByAltText, getByText } = renderUtils;
-      expect(getByAltText(/Puzzle Piece Icon/i)).toBeTruthy();
-      expect(getByText(/Approval Permissions Revoked/i)).toBeTruthy();
-    });
-  });
-
-  describe('default state, no apds', () => {
-    beforeEach(() => {
-      mockAxios.get.mockImplementation(() => Promise.resolve({ data: [] }));
-      renderUtils = renderWithConnection(
-        <StateDashboard {...props} pending={false} />,
-        {
-          initialState: {
-            user: {
-              data: {
-                state: { id: 'mo' },
-                affiliations: [
-                  {
-                    state_id: 'mo',
-                    status: STATE_AFFILIATION_STATUSES.APPROVED
-                  }
-                ]
-              }
-            }
-          }
-        }
-      );
-    });
-
-    it('should display the introduction and instructions', () => {
-      const { queryByText } = renderUtils;
-      expect(
-        queryByText(
-          /The CMS HITECH APD app is the new way to create and manage/i
-        )
-      ).toBeTruthy();
-      expect(queryByText(/All your state's APDs are listed here./i)).toBeNull();
-    });
-
-    it('should handle clicking the create APD button', async () => {
-      mockAxios.post.mockImplementation(() => Promise.resolve({ data: apd }));
-      const { queryByRole } = renderUtils;
-      expect(queryByRole('button', { name: /Create new/i })).toBeTruthy();
-      // fireEvent.click(queryByRole('button', { name: /Create new/i }));
-      // expect(props.createApd).toHaveBeenCalled();
-    });
-
-    it('should display the empty APD message', () => {
-      const { queryByText } = renderUtils;
-      expect(queryByText(/You have not created any APDs./i)).toBeTruthy();
-    });
-
-    it("shouldn't display the pending message", () => {
-      const { queryByAltText, queryByText } = renderUtils;
-      expect(queryByAltText(/Puzzle Piece Icon/i)).toBeNull();
-      expect(
-        queryByText(/Approval Pending From State Administrator/i)
-      ).toBeNull();
-    });
-  });
-
-  describe('default state with apds', () => {
-    beforeEach(() => {
-      mockAxios.get.mockImplementation(() => Promise.resolve({ data: [apd] }));
-      renderUtils = renderWithConnection(
-        <StateDashboard {...props} pending={false} />,
-        {
-          initialState: {
-            user: {
-              data: {
-                state: { id: 'mo' },
-                affiliations: [
-                  {
-                    state_id: 'mo',
-                    status: STATE_AFFILIATION_STATUSES.APPROVED
-                  }
-                ]
-              }
-            },
-            apd: {
-              byId: {
-                [apd.id]: {
-                  ...apd,
-                  created: createdStr,
-                  updated: updatedStr
-                }
-              }
-            }
-          }
-        }
-      );
-    });
-
-    it('should display the APD', () => {
-      const { getByText } = renderUtils;
-      expect(getByText(apd.name)).toBeTruthy();
-      expect(getByText(updatedStr)).toBeTruthy();
-      expect(getByText(createdStr)).toBeTruthy();
-    });
-
-    it('should allow the user to click on the APD to edit', () => {
-      const { getByText } = renderUtils;
-      expect(getByText(apd.name)).toBeTruthy();
-      // fireEvent.click(getByText(apd.name));
-      // expect(props.selectApd).toHaveBeenCalledWith(apd.id, props.route);
-    });
-
-    it('should allow the user to click the delete APD button', () => {
-      const { getByText } = renderUtils;
-      expect(getByText(/Delete/i)).toBeTruthy();
-      // fireEvent.click(getByText(/Delete/i));
-      // expect(props.deleteApd).toHaveBeenCalledWith(apd);
-    });
+  it('renders <StateAffiliationStatus /> otherwise', () => {
+    const component = setup({ stateStatus: '' });
+    expect(component.find(StateAffiliationStatus).exists()).toBe(true);
   });
 });


### PR DESCRIPTION
### This pull request changes...

- no functional changes
- `<StateDashboard/>` conditionally loads `<ApdList/>` or `<StateAffiliationStatus/>`

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has approved the experience
- [ ] Design has approved the experience
- [ ] Product has approved the experience
