### PR TITLE
Add Watch Option to PM2

### DIFF
--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -116,7 +116,7 @@ function createNewInstance() {
     --subnet-id "$AWS_SUBNET" \
     --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}}]" \
     --user-data file://aws.user-data.sh \
-    --key-name eapd_bbrooks
+    --key-name eapd_bbrooks \
     | jq -r -c '.Instances[0].InstanceId'
 }
 

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -116,6 +116,7 @@ function createNewInstance() {
     --subnet-id "$AWS_SUBNET" \
     --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}}]" \
     --user-data file://aws.user-data.sh \
+    --key-name eapd_bbrooks
     | jq -r -c '.Instances[0].InstanceId'
 }
 

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -414,7 +414,7 @@ echo "module.exports = {
 };" > ecosystem.config.js
 
 # Start it up
-pm2 start ecosystem.config.js
+pm2 start ecosystem.config.js --watch
 
 E_USER
 

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -283,7 +283,7 @@ npm rebuild knex
 echo "__ECOSYSTEM__" | base64 --decode > ecosystem.config.js
 
 # Start it up
-pm2 start ecosystem.config.js
+pm2 start ecosystem.config.js --watch
 
 E_USER
 


### PR DESCRIPTION
Add the watch option to our pm2 setup so that if the api goes down it should be restarted automatically.

### This pull request changes...

- pm2 is watching the api process
- Killing pm2 api pid will result in pm2 restarting api

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has approved the experience
- [ ] Design has approved the experience
- [ ] Product has approved the experience
