### PR TITLE
PM2 Watch as Configuration

### DIFF
--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -391,6 +391,7 @@ echo "module.exports = {
     script: 'main.js',
     instances: 1,
     autorestart: true,
+    watch: true,
     error_file: '/app/api/logs/eAPD-API-error-0.log',
     out_file: '/app/api/logs/eAPD-API-out-0.log',
     env: {
@@ -414,7 +415,7 @@ echo "module.exports = {
 };" > ecosystem.config.js
 
 # Start it up
-pm2 start ecosystem.config.js --watch
+pm2 start ecosystem.config.js
 
 E_USER
 

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -125,6 +125,7 @@ function addEcosystemToUserData() {
       script: 'main.js',
       instances: 1,
       autorestart: true,
+      watch: true,
       error_file: '/app/api/logs/eAPD-API-error-0.log',
       out_file: '/app/api/logs/eAPD-API-out-0.log',
       env: {


### PR DESCRIPTION
Changing from command flag to configuration for pm2 watch

### This pull request changes...

- pm2 watches the api backend process and restarts it if it fails

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has approved the experience
- [ ] Design has approved the experience
- [ ] Product has approved the experience
