### PR TITLE
Removed watch option from pm2 ecosystem file

### DIFF
--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -366,7 +366,6 @@ echo "module.exports = {
     script: 'main.js',
     instances: 1,
     autorestart: true,
-    watch: true,
     error_file: '/app/api/logs/eAPD-API-error-0.log',
     out_file: '/app/api/logs/eAPD-API-out-0.log',
     env: {

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -125,7 +125,6 @@ function addEcosystemToUserData() {
       script: 'main.js',
       instances: 1,
       autorestart: true,
-      watch: true,
       error_file: '/app/api/logs/eAPD-API-error-0.log',
       out_file: '/app/api/logs/eAPD-API-out-0.log',
       env: {


### PR DESCRIPTION
PenTesting will be ongoing for an additional week and the watch option currently results in deployments that fail to come up healthy and require manual intervention.

### This pull request changes...

- Watch option is removed from ecosystem file
- API/Backened comes up healthy upon provision

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has approved the experience
- [ ] Design has approved the experience
- [ ] Product has approved the experience
