### PR TITLE
AWS CloudWatch Alarms to Slack

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,7 @@
+variable "eapd_slack_webhook_url" {}
+variable "eapd_slack_channel" {}
+variable "eapd_slack_username" {}
+
 terraform {
   backend "s3" {
     bucket         = "eapd-terraform-state"
@@ -19,4 +23,25 @@ provider "aws" {
 
 module "buckets" {
     source = "./modules/buckets"
+}
+
+data "aws_sns_topic" "aws_500x_errors" {
+  name = "HTTPCode_ELB_5XX_Count_Alarms"
+}
+
+module "notify_slack" {
+  source = "../../../terraform-aws-notify-slack" # Hardcoded local path
+
+  sns_topic_name   = data.aws_sns_topic.aws_500x_errors.name
+  create_sns_topic = false
+
+  slack_webhook_url = var.eapd_slack_webhook_url
+  slack_channel     = var.eapd_slack_channel
+  slack_username    = var.eapd_slack_username
+
+  tags = {
+    Name = "notify-slack-simple"
+  }
+
+  depends_on = [data.aws_sns_topic.aws_500x_errors]
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,45 @@
+
+output "this_sns_topic_arn" {
+  description = "The ARN of the SNS topic from which messages will be sent to Slack"
+  value       = module.notify_slack.this_slack_topic_arn
+}
+
+output "lambda_iam_role_arn" {
+  description = "The ARN of the IAM role used by Lambda function"
+  value       = module.notify_slack.lambda_iam_role_arn
+}
+
+output "lambda_iam_role_name" {
+  description = "The name of the IAM role used by Lambda function"
+  value       = module.notify_slack.lambda_iam_role_name
+}
+
+output "notify_slack_lambda_function_arn" {
+  description = "The ARN of the Lambda function"
+  value       = module.notify_slack.notify_slack_lambda_function_arn
+}
+
+output "notify_slack_lambda_function_name" {
+  description = "The name of the Lambda function"
+  value       = module.notify_slack.notify_slack_lambda_function_name
+}
+
+output "notify_slack_lambda_function_invoke_arn" {
+  description = "The ARN to be used for invoking Lambda function from API Gateway"
+  value       = module.notify_slack.notify_slack_lambda_function_invoke_arn
+}
+
+output "notify_slack_lambda_function_last_modified" {
+  description = "The date Lambda function was last modified"
+  value       = module.notify_slack.notify_slack_lambda_function_last_modified
+}
+
+output "notify_slack_lambda_function_version" {
+  description = "Latest published version of your Lambda function"
+  value       = module.notify_slack.notify_slack_lambda_function_version
+}
+
+output "lambda_cloudwatch_log_group_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the log group"
+  value       = module.notify_slack.lambda_cloudwatch_log_group_arn
+}


### PR DESCRIPTION
Prod and Impl/Staging AWS CloudWatch Alarms will go to the eAPD Slack notifications channel.

### This pull request changes...

- Prod AWS CloudWatch 5XX Alarm posts to eAPD Slack notification channel
- Impl AWS CloudWatch 5XX Alarm posts to eAPD Slack notification channel

### This is how to verify this change...

### This pull request is ready to merge when...

- [ ] Develop has updated automated tests (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] QA has manually tested and created bugs for any issues found (beyond minor fixes)
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
