### PR TITLE
Remove Curl Backend Test for Staging/Prod

### DIFF
--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -104,19 +104,6 @@ function deployAPItoEC2() {
     echo "Environment $ENVIRONMENT is invalid"
   fi
 
-  echo "• Checking availability of Backend"
-  if [[ $ENVIRONMENT == "production" ]]; then
-    while [[ "$(curl -s -o /dev/null -w %{http_code} https://eapd-api.cms.gov/heartbeat)" != "204" ]]; 
-      do echo "• • Backend currently unavailable" && sleep 60; 
-    done
-  elif [[ $ENVIRONMENT == "staging" ]]; then
-    while [[ "$(curl -s -o /dev/null -w %{http_code} https://staging-eapd-api.cms.gov/heartbeat)" != "204" ]]; 
-      do echo "• • Backend currently unavailable" && sleep 60; 
-    done
-  else
-    echo "Environment $ENVIRONMENT is invalid"
-  fi
-
   # And finally, we terminate previous instances.
   while read -r PREV_INSTANCE_INFO; do
     BITS=(${PREV_INSTANCE_INFO//,/ })


### PR DESCRIPTION
Removed the backend health check for Staging/Prod, because AWS is already doing a health check on the /heartbeat endpoint and the curl tests were reporting that the backend isn't up, while the AWS health test was passing.

### This pull request changes...

- Removes redundant healthcheck on /heartbeat

### This is how to verify this change...

### This pull request is ready to merge when...

- [ ] Develop has updated automated tests (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] QA has manually tested and created bugs for any issues found (beyond minor fixes)
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
