### PR TITLE
Adding Exemption Tags for Web Access

### DIFF
--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -133,7 +133,7 @@ function createNewInstance() {
     --image-id $1 \
     --security-group-ids "$AWS_SECURITY_GROUP" \
     --subnet-id "$AWS_SUBNET" \
-    --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}},{Key=cms-cloud-exempt:open-sg,Value=CLDSPT-5877]" \
+    --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}},{Key=cms-cloud-exempt:open-sg,Value=CLDSPT-5877}]" \
     --user-data file://aws.user-data.sh \
     --key-name eapd_bbrooks \
     | jq -r -c '.Instances[0].InstanceId'

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -133,7 +133,7 @@ function createNewInstance() {
     --image-id $1 \
     --security-group-ids "$AWS_SECURITY_GROUP" \
     --subnet-id "$AWS_SUBNET" \
-    --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}}]" \
+    --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}},{Key=cms-cloud-exempt:open-sg,Value=CLDSPT-5877]" \
     --user-data file://aws.user-data.sh \
     --key-name eapd_bbrooks \
     | jq -r -c '.Instances[0].InstanceId'

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -228,7 +228,7 @@ function createNewInstance() {
     --security-group-ids $AWS_SECURITY_GROUP \
     --subnet-id $AWS_SUBNET \
     --ebs-optimized \
-    --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD $ENVIRONMENT},{Key=environment,Value=$ENVIRONMENT}]" \
+    --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD $ENVIRONMENT},{Key=environment,Value=$ENVIRONMENT},{Key=cms-cloud-exempt:open-sg,Value=CLDSPT-5877}]" \
     --user-data file://aws.user-data.sh \
     | jq -r -c '.Instances[0].InstanceId'
 }


### PR DESCRIPTION
This PR adds tags to our instances that require web access so that they are not flagged in a security compliance scan. I have manually added the tags on or more persistent resources; Production, Staging, and Load Balancers, Security Groups, and this will address any new instances that are provisioned.

### This pull request changes...

- Newly provisioned instances will receive the appropriate tags

### This is how to verify this change...

### This pull request is ready to merge when...

- [ ] Develop has updated automated tests (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] QA has manually tested and created bugs for any issues found (beyond minor fixes)
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
