### PR TITLE
making OKTA environment variables available when the ec2-user logs in

### DIFF
--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -230,6 +230,10 @@ CWAPPLOGCONFIG
 su ec2-user <<E_USER
 # The su block begins inside the root user's home directory.  Switch to the
 # ec2-user home directory.
+export OKTA_DOMAIN="__OKTA_DOMAIN__"
+export OKTA_SERVER_ID="__OKTA_SERVER_ID__"
+export OKTA_CLIENT_ID="__OKTA_CLIENT_ID__"
+export OKTA_API_KEY="__OKTA_API_KEY__"
 cd ~
 mkdir -p /app/api/logs
 touch /app/api/logs/eAPD-API-error-0.log


### PR DESCRIPTION
**Description-**

The database migrations were not being run in Staging and Production. After some investigation, I determined that it was because the OKTA environment variables were not available when the migrations were run.

**This pull request changes...**

- exported OKTA variables when ec2-user logs in

**Steps to manually verify this change...**

1. This cannot be verified until it's in Staging and Prod, after it's been merged I can test it by looking at the logs in AWS.

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] Product has approved the experience
