### PR TITLE
Tbolt/3159  Updates Key Personnel section to show a message when no information is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Anticipated release: June 3, 2021
 
 - Update APD paths to include APD id ([#2589])
 - Updates date validation and formatting to be more accurate ([#3086])
+- Update Key Personnel and Program Management page to show if no information has been entered ([#3159])
 
 #### 🐛 Bugs fixed
 
@@ -23,3 +24,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#2811]: https://github.com/CMSgov/eAPD/issues/2811
 [#2976]: https://github.com/CMSgov/eAPD/issues/2976
 [#3086]: https://github.com/CMSgov/eAPD/issues/3086
+[#3159]: https://github.com/CMSgov/eAPD/issues/3159

--- a/web/src/containers/viewOnly/ApdStateProfile.js
+++ b/web/src/containers/viewOnly/ApdStateProfile.js
@@ -77,7 +77,9 @@ const ApdStateProfile = ({ stateProfile, keyPersonnel }) => {
       <hr className="section-rule" />
       <h2>Key Personnel and Program Management</h2>
       <ol className="ds-u-padding-left--0">
-        {keyPersonnel.map((person, index) => buildPerson(person, index))}
+        {keyPersonnel.length > 0 
+          ? keyPersonnel.map((person, index) => buildPerson(person, index)) 
+          : 'No response was provided'}
       </ol>
     </div>
   );

--- a/web/src/containers/viewOnly/ApdStateProfile.test.js
+++ b/web/src/containers/viewOnly/ApdStateProfile.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from 'apd-testing-library'
+
+import ApdStateProfile from './ApdStateProfile';
+
+describe('APD Summary/viewOnly component', () => {
+  test('renders the correct message when no key personnel are provided', () => {
+    const stateProfile = {
+      medicaidOffice: {},
+      medicaidDirector: {}
+    };
+    render(<ApdStateProfile stateProfile={stateProfile} keyPersonnel={[]} />);
+    expect(screen.queryByText(/No response was provided/i)).toBeTruthy();
+  });
+
+  test('renders key personnel when provided', () => {
+    const stateProfile = {
+      medicaidOffice: {},
+      medicaidDirector: {}
+    };
+    const keyPersonnel = [{
+      isPrimary:true,
+      name:"Primary Person Name",
+    }]
+    render(<ApdStateProfile stateProfile={stateProfile} keyPersonnel={keyPersonnel} />);
+    expect(screen.queryByText(/Primary Person Name/i)).toBeTruthy();
+    expect(screen.queryByText(/Primary APD Point of Contact/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Resolves #3159 

**Description-**

**This pull request changes...**

-  Updates Key Personnel section to show a "No response was provided" message when no information is provided

**Steps to manually verify this change...**

1. Login with any account able to create an APD
2. Crete a new APD
3. Go to export view and verify that the "No response was provided" is there under Key State Personnel
4. Compare with the proposed design
5. Enter information for that section and verify it appears on the export view

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
