### PR TITLE
Tbolt/3147 Remove extra header in budget and ffp export view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Anticipated release: June 3, 2021
 #### ⚙️ Behind the scenes
 
 - Allowed Federal Admins to get and approve pending affiliations ([#2811])
+- Removes extraneous header for Budget and FPP in the export view ([#3147])
 
 # Previous releases
 
@@ -33,3 +34,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#3011]: https://github.com/CMSgov/eAPD/issues/3011
 [#3086]: https://github.com/CMSgov/eAPD/issues/3086
 [#3126]: https://github.com/CMSgov/eAPD/issues/3126
+[#3147]: https://github.com/CMSgov/eAPD/issues/3147

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -113,7 +113,9 @@ const CostAllocateFFP = ({
 
   return (
     <Fragment>
-      <h2 className="subsection--title ds-h2">Budget and FFP</h2>
+      {isViewOnly
+        ? <hr className="custom-hr" />
+        : <h2 className="subsection--title ds-h2">Budget and FFP</h2> }
       {Object.keys(years).map(ffy => (
         <Fragment key={ffy}>
           <table

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
@@ -748,11 +748,9 @@ exports[`the CostAllocateFFP component renders correctly renders correctly in ed
 
 exports[`the CostAllocateFFP component renders correctly renders correctly in view-only mode 1`] = `
 <Fragment>
-  <h2
-    className="subsection--title ds-h2"
-  >
-    Budget and FFP
-  </h2>
+  <hr
+    className="custom-hr"
+  />
   <table
     className="budget-table activity-budget-table"
     id="activity0-ffy1990"

--- a/web/src/containers/viewOnly/activities/Activity.js
+++ b/web/src/containers/viewOnly/activities/Activity.js
@@ -309,7 +309,7 @@ const Activity = ({ activity, activityIndex }) => {
           Activity {activityIndex + 1} ({activity.name})
         </small>
         <br />
-        Budget and Federal Financial Participation (FFP)
+        Budget and FFP
       </h3>
       <CostAllocateFFP
         aKey={activity.key}


### PR DESCRIPTION
resolves #3147 

**Description-**
Updates the export view in the budget and ffp section to match proposed design

- Removes extra "Budget and FFP" heading, renames existing heading

**Steps to manually verify this change...**

1. Login with any account that can create an APD
2. Navigate to export view
3. Verify that under an Activities Budget and FFP sections the headings have been updated to match proposed design

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
