### PR TITLE
Knollfear/3091 use okta data affiliations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,19 @@
 # Next release
 
-Anticipated release: June 3, 2021
+Anticipated release: June 28, 2021
 
 #### 🚀 New features
-- Allow multiple states to be selected in onboarding process ([#2638])
-
-- Allow multiple states to be selected in onboarding process ([#2638])
-- Update APD paths to include APD id ([#2589])
-- Update APD Overview page to show if no information has been entered ([#3157])
-- Additional affiliations may be requested ([#2582])
-- On the state affiliation selection page, give users an option to log out ([#3011])
-- Updates date validation and formatting to be more accurate ([#3086])
-- Update Key State Personnel page to show if no information has been entered ([#3158])
-- Update Key Personnel and Program Management page to show if no information has been entered ([#3159])
 
 #### 🐛 Bugs fixed
 
-- Investigate why rich text editor is losing formatting after page reload ([#2961])
-- Add activity label on nav isn't accurate ([#3010])
-- Refreshing Page Traps the User on Validating the Session ([#2976])
-- Resolves an issue where logging out did not actually log you out on the first attempt ([#3126])
-
 #### ⚙️ Behind the scenes
 
-- Allowed Federal Admins to get and approve pending affiliations ([#2811])
+- Use Local Okta User data instead of contacting Okta when populating affiliations ([#3091])
 - Removes extraneous header for Budget and FPP in the export view ([#3147])
 
 # Previous releases
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
-[#2582]: https://github.com/CMSgov/eAPD/issues/2582
-[#2589]: https://github.com/CMSgov/eAPD/issues/2589
-[#2811]: https://github.com/CMSgov/eAPD/issues/2811
-[#2961]: https://github.com/CMSgov/eAPD/issues/2961
-[#2976]: https://github.com/CMSgov/eAPD/issues/2976
-[#3010]: https://github.com/CMSgov/eAPD/issues/3010
-[#3011]: https://github.com/CMSgov/eAPD/issues/3011
-[#3086]: https://github.com/CMSgov/eAPD/issues/3086
-[#3126]: https://github.com/CMSgov/eAPD/issues/3126
+[#3091]: https://github.com/CMSgov/eAPD/issues/3091
 [#3147]: https://github.com/CMSgov/eAPD/issues/3147
-[#3157]: https://github.com/CMSgov/eAPD/issues/3157
-[#3158]: https://github.com/CMSgov/eAPD/issues/3158
-[#3159]: https://github.com/CMSgov/eAPD/issues/3159

--- a/api/migrations/20210614180421_okta-users-primary-key.js
+++ b/api/migrations/20210614180421_okta-users-primary-key.js
@@ -1,0 +1,12 @@
+
+exports.up = async knex => {
+    await knex.schema.table('okta_users', table => {
+        table.primary('user_id');
+    });
+};
+
+exports.down = async knex => {
+    await knex.schema.table('okta_users', table => {
+        table.dropPrimary()
+    });
+};

--- a/api/seeds/development/base-users.js
+++ b/api/seeds/development/base-users.js
@@ -4,9 +4,11 @@ const { oktaClient } = require('../../auth/oktaAuth');
 const { createUsersToAdd } = require('../shared/set-up-users');
 
 exports.seed = async knex => {
-  const {oktaAffiliations, stateCertifications} = await createUsersToAdd(knex, oktaClient);
+  const {oktaAffiliations, stateCertifications, oktaUsers} = await createUsersToAdd(knex, oktaClient);
   await knex('auth_affiliations').insert(oktaAffiliations);
   logger.info('Completed adding affiliations');
+  await knex('okta_users').insert(oktaUsers)
+  logger.info('Completed adding okta_users');
   await knex('state_admin_certifications').insert(stateCertifications)
   const auditEntries = stateCertifications.map(certification =>{
     return {


### PR DESCRIPTION
resolves #3091

**Description-**

**This pull request changes...**

-pulls Okta User data from the local database instead of Okta
- stores additional okta_users data in the seed process.

**This pull request also touches…**

- any time affiliation lists are fetched

**This pull request was tested in the follow ways…**

- Log in as different types of admin and go to the state admin page.
- Updated unit tests to account for the removal of requests to okta

**Steps to manually verify this change...**

1. Update the DB for any user to have a different email or phone number
2. In this version the updated number will show on the state admin page.  In older versions the data in the DB is not read, so changing it will have no effect.
3. In another ticket in this branch okta data is captured on login so if you log in know that your okta data may change.

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
