### PR TITLE
Updating modal when unable to save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Anticipated release: June 3, 2021
 - On the state affiliation selection page, give users an option to log out ([#3011])
 - Updates date validation and formatting to be more accurate ([#3086])
 - Update Key State Personnel page to show if no information has been entered ([#3158])
-
+- Updated modal that displays when saving an APD fails ([#2997])
 #### 🐛 Bugs fixed
 
 - Investigate why rich text editor is losing formatting after page reload ([#2961])
@@ -32,6 +32,7 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#2811]: https://github.com/CMSgov/eAPD/issues/2811
 [#2961]: https://github.com/CMSgov/eAPD/issues/2961
 [#2976]: https://github.com/CMSgov/eAPD/issues/2976
+[#2997]: https://github.com/CMSgov/eAPD/issues/2997
 [#3010]: https://github.com/CMSgov/eAPD/issues/3010
 [#3011]: https://github.com/CMSgov/eAPD/issues/3011
 [#3086]: https://github.com/CMSgov/eAPD/issues/3086

--- a/web/src/containers/UnexpectedError.js
+++ b/web/src/containers/UnexpectedError.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { Spinner } from '../components/Icons';
+import Icon, { faExclamationTriangle, Spinner } from '../components/Icons';
 
 import { saveApd } from '../actions/app';
 import { selectHasError, selectIsSaving } from '../reducers/saving';
@@ -16,7 +16,15 @@ const UnexpectedError = ({ hasError, isSaving, save }) => {
   return (
     <div aria-live="polite">
       {hasError && (
-        <Dialog heading="Unable to save changes!" onExit={closeErrorAlert}>
+        <Dialog
+          heading={
+            <div>
+              <Icon icon={faExclamationTriangle} /> Unable to save changes!
+            </div>
+          }
+          onExit={closeErrorAlert}
+          className="ds-u-left-border-warning"
+        >
           <p>
             Your changes aren&apos;t being saved. Verify your internet
             connection and try saving your changes again in a few minutes by

--- a/web/src/containers/__snapshots__/UnexpectedError.test.js.snap
+++ b/web/src/containers/__snapshots__/UnexpectedError.test.js.snap
@@ -6,11 +6,47 @@ exports[`the unexpected error alert component renders as expected if there is an
 >
   <Dialog
     ariaCloseLabel="Close modal dialog"
+    className="ds-u-left-border-warning"
     closeButtonText="Close"
     closeButtonVariation="transparent"
     escapeExitDisabled={false}
     escapeExits={true}
-    heading="Unable to save changes!"
+    heading={
+      <div>
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f071",
+                "M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z",
+              ],
+              "iconName": "exclamation-triangle",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Unable to save changes!
+      </div>
+    }
     onExit={[Function]}
     underlayClickExits={false}
   >
@@ -49,11 +85,47 @@ exports[`the unexpected error alert component renders as expected if there is an
 >
   <Dialog
     ariaCloseLabel="Close modal dialog"
+    className="ds-u-left-border-warning"
     closeButtonText="Close"
     closeButtonVariation="transparent"
     escapeExitDisabled={false}
     escapeExits={true}
-    heading="Unable to save changes!"
+    heading={
+      <div>
+        <FontAwesomeIcon
+          border={false}
+          className=""
+          fixedWidth={false}
+          flip={null}
+          icon={
+            Object {
+              "icon": Array [
+                576,
+                512,
+                Array [],
+                "f071",
+                "M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z",
+              ],
+              "iconName": "exclamation-triangle",
+              "prefix": "fas",
+            }
+          }
+          inverse={false}
+          listItem={false}
+          mask={null}
+          pull={null}
+          pulse={false}
+          rotation={null}
+          size={null}
+          spin={false}
+          swapOpacity={false}
+          symbol={false}
+          title=""
+          transform={null}
+        />
+         Unable to save changes!
+      </div>
+    }
     onExit={[Function]}
     underlayClickExits={false}
   >


### PR DESCRIPTION
resolves #

**Description-**
 updated error modal with the left warning class and added a warning icon to the header.
**This pull request changes...**

- the unexpected error dialog to match the mock ups.

**This pull request also touches…**

- none.  This was a CSS and minor text change only.

**This pull request was tested in the follow ways…**

- Logged in
- opened an APD
- stopped docker containers
- edited APD
- got the warning message and confirmed it matched the mock up.

**Steps to manually verify this change...**

1. see above

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
