### PR TITLE
fixing storing of Okta data on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Anticipated release: July 9, 2021
 
 #### 🐛 Bugs fixed
 
+- Fixed issue with not storing okta data on login ([#3242])
 
 #### ⚙️ Behind the scenes
 
@@ -19,3 +20,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 
 [#2996]: https://github.com/CMSgov/eAPD/issues/2996
 [#3030]: https://github.com/CMSgov/eAPD/issues/3030
+[#3242]: https://github.com/CMSgov/eAPD/issues/3242

--- a/api/routes/me/get.js
+++ b/api/routes/me/get.js
@@ -1,23 +1,25 @@
 const logger = require('../../logger')('me route get');
 const { jwtExtractor, verifyEAPDToken, exchangeToken, verifyWebToken } = require('../../auth/jwtUtils');
+const { createOrUpdateOktaUserFromOkta } = require('../../db/oktaUsers')
 
 module.exports = (
   app,
   {
     extractor = jwtExtractor,
     verifier = verifyEAPDToken,
-    tokenExchanger = exchangeToken
+    tokenExchanger = exchangeToken,
+    updateFromOkta = createOrUpdateOktaUserFromOkta
 
   } = {}
 ) => {
   logger.debug('setting up GET endpoint');
   app.get('/me',
     async (req, res) => {
-
     try{
       const jwt = extractor(req)
       const claims = jwt ? await verifyWebToken(jwt, {verifier}) : false;
       if (!claims) return res.status(401).end();
+      await updateFromOkta(claims.id)
       res.send(claims);
 
     }

--- a/api/routes/me/get.test.js
+++ b/api/routes/me/get.test.js
@@ -9,7 +9,7 @@ let app;
 let res;
 const req = { jwt: 'aaaa.bbbb.cccc' }
 const user = {uid: 1234, state:{id: 'ak'}}
-const claims = {claims: 'this is a claim'}
+const claims = {id:123, claims: 'this is a claim'}
 
 tap.test('me GET endpoint', async endpointTest => {
   endpointTest.beforeEach(async () => {
@@ -35,7 +35,7 @@ tap.test('me GET endpoint', async endpointTest => {
 
     eapdTokenVerifier.withArgs(req.jwt).resolves(claims)
 
-    getEndpoint(app, {extractor, verifier:eapdTokenVerifier});
+    getEndpoint(app, {extractor, verifier:eapdTokenVerifier, updateFromOkta});
     const meHandler = app.get.args.filter(arg => arg[0] === '/me')[0][1];
 
     await meHandler(req, res);

--- a/api/routes/me/get.test.js
+++ b/api/routes/me/get.test.js
@@ -29,6 +29,7 @@ tap.test('me GET endpoint', async endpointTest => {
   endpointTest.test('get me handler', async test => {
     const extractor = sinon.stub()
     const eapdTokenVerifier = sinon.stub()
+    const updateFromOkta = sinon.stub()
 
     extractor.withArgs(req).returns(req.jwt)
 
@@ -47,6 +48,10 @@ tap.test('me GET endpoint', async endpointTest => {
     test.ok(
       eapdTokenVerifier.calledWith(req.jwt),
       'calls the token extractor with the request'
+    )
+
+    test.ok(
+      updateFromOkta.calledWith(123)
     )
 
     test.ok(


### PR DESCRIPTION
Replacing code that went missing.  This is not at all new code, but rather code that got squashed in a merge conflict previously.

resolves #3242

**Description-**

**This pull request changes...**

- adds in a request for data from Okta to the /me endpoint

**This pull request also touches…**

- possible side effects of this change

none. This is all code that has been previously approved, it just seems to have disappeared in a merge conflict.

**This pull request was tested in the follow ways…**

- select * from okta_users to see what data exists for users in the DB
- alter data as you see fit
- log in and see if the data appears, or if it was altered is changed back

**Steps to manually verify this change...**

1. okta_user data is displayed on the affiliation request approval screen.  If a user has data on that table it will be on this screen.

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
