### PR TITLE
Knollfear/3246 connect state certification table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Anticipated release: July 9, 2021
 #### 🚀 New features
 
 - Update the delete process for FFY ([#2996])
+- Users are upgraded to State Admin if they have a current state certification ([#3246])
 
 #### 🐛 Bugs fixed
 
@@ -19,3 +20,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 
 [#2996]: https://github.com/CMSgov/eAPD/issues/2996
 [#3030]: https://github.com/CMSgov/eAPD/issues/3030
+[#3246]: https://github.com/CMSgov/eAPD/issues/3246

--- a/api/db/auth.js
+++ b/api/db/auth.js
@@ -113,8 +113,8 @@ const getUserPermissionsForStates = async (userId, { db = knex } = {}) => {
 const isAdminForState = async (userId, stateId, {db = knex} = {}) => {
   const results = await db('auth_affiliations')
     .select('auth_affiliations.state_id')
-    .join('state_admin_certifications', () => {
-      this.on(() => {
+    .join('state_admin_certifications', function joinFunc() {
+      this.on(function joinOnFunc() {
         this.on('state_admin_certifications.username', '=', 'auth_affiliations.user_id')
         this.andOn('state_admin_certifications.state', '=', 'auth_affiliations.state_id')
       })

--- a/api/db/dbMock.test.js
+++ b/api/db/dbMock.test.js
@@ -21,7 +21,8 @@ const getQueryBuilder = () => ({
   whereIn: sandbox.stub(),
   whereRaw: sandbox.stub(),
   leftJoin: sandbox.stub(),
-  whereNot:sandbox.stub()
+  whereNot:sandbox.stub(),
+  join: sandbox.stub()
 });
 
 const creator = table => {

--- a/api/db/users.test.js
+++ b/api/db/users.test.js
@@ -7,7 +7,8 @@ const {
   getAllUsers,
   getUserByID,
   populateUser,
-  sanitizeUser
+  sanitizeUser,
+  actualGetRole
 } = require('./users');
 
 tap.test('database wrappers / users', async usersTests => {
@@ -48,6 +49,10 @@ tap.test('database wrappers / users', async usersTests => {
     states: []
   };
 
+  const roles = [
+    {id: 1, name:'role', activities:['activity']},
+    {id: 2, name:'eAPD State Admin', activities:['admin', 'activity']},
+  ]
   // let getUserPermissionsForStates;
   // let getUserAffiliatedStates;
   // let getAffiliationsByUserId;
@@ -462,4 +467,24 @@ tap.test('database wrappers / users', async usersTests => {
       }
     );
   });
+
+  usersTests.test('getting a role for an affiliation', async test => {
+    const getRolesAndActivities =  sinon.stub()
+    const isAdminForState = sinon.stub()
+    const affiliation = {user_id: 'user_id', state_id:'al', role_id:1}
+    getRolesAndActivities.withArgs().resolves(roles)
+    isAdminForState.withArgs('user_id', 'al').resolves(false)
+    test.same(await actualGetRole(affiliation, {getRolesAndActivities, isAdminForState }), roles[0])
+
+  })
+
+  usersTests.test('getting a role for an affiliation that is promoted to admin', async test => {
+    const getRolesAndActivities =  sinon.stub()
+    const isAdminForState = sinon.stub()
+    const affiliation = {user_id: 'user_id', state_id:'ak', role_id:1}
+    getRolesAndActivities.withArgs().resolves(roles)
+    isAdminForState.withArgs('user_id', 'ak').resolves(true)
+    test.same(await actualGetRole(affiliation, {getRolesAndActivities, isAdminForState }), roles[1])
+
+  })
 });

--- a/api/seeds/shared/set-up-users.js
+++ b/api/seeds/shared/set-up-users.js
@@ -80,7 +80,8 @@ const createUsersToAdd = async (knex, oktaClient) => {
       state_id: 'ak',
       role_id: stateAdminRoleId,
       status: 'approved',
-      updated_by: 'seeds'
+      updated_by: 'seeds',
+      username: regularUser.profile.displayName
     });
     // Add an expired certification and this user will be downgraded to "regular user"
     stateCertifications.push({
@@ -109,9 +110,26 @@ const createUsersToAdd = async (knex, oktaClient) => {
     oktaAffiliations.push({
       user_id: stateAdmin.id,
       state_id: 'ak',
-      role_id: stateAdminRoleId,
+      role_id: stateStaffRoleId,
       status: 'approved',
-      updated_by: 'seeds'
+      updated_by: 'seeds',
+      username: stateAdmin.profile.displayName
+    });
+    oktaAffiliations.push({
+      user_id: stateAdmin.id,
+      state_id: 'ar',
+      role_id: stateStaffRoleId,
+      status: 'approved',
+      updated_by: 'seeds',
+      username: stateAdmin.profile.displayName
+    });
+    oktaAffiliations.push({
+      user_id: stateAdmin.id,
+      state_id: 'al',
+      role_id: stateStaffRoleId,
+      status: 'approved',
+      updated_by: 'seeds',
+      username: stateAdmin.profile.displayName
     });
     // Let them be a staffer in Maryland too
     oktaAffiliations.push({
@@ -119,7 +137,8 @@ const createUsersToAdd = async (knex, oktaClient) => {
       state_id: 'md',
       role_id: stateStaffRoleId,
       status: 'approved',
-      updated_by: 'seeds'
+      updated_by: 'seeds',
+      username: stateAdmin.profile.displayName
     });
     // Add a valid certification and this user will remain an admin
     stateCertifications.push({
@@ -128,6 +147,28 @@ const createUsersToAdd = async (knex, oktaClient) => {
       certificationDate: format(subDays(new Date(), 40), PostgresDateFormat),
       certificationExpiration: format(
         addDays(new Date(), 325),
+        PostgresDateFormat
+      ),
+      certifiedBy: 'seeds'
+    })
+    // admin for Arkansas too
+    stateCertifications.push({
+      username: stateAdmin.id,
+      state: 'ar',
+      certificationDate: format(subDays(new Date(), 40), PostgresDateFormat),
+      certificationExpiration: format(
+        addDays(new Date(), 325),
+        PostgresDateFormat
+      ),
+      certifiedBy: 'seeds'
+    })
+
+    stateCertifications.push({
+      username: stateAdmin.id,
+      state: 'al',
+      certificationDate: format(subDays(new Date(), 405), PostgresDateFormat),
+      certificationExpiration: format(
+        subDays(new Date(), 40),
         PostgresDateFormat
       ),
       certifiedBy: 'seeds'


### PR DESCRIPTION
resolves #3246

**Description-**

This connects the state certification table to the permissions model.  If a user has a valid state certification, they will be granted admin permissions for that state, regardless of any other affiliation or role.

**This pull request changes...**

- How activities are calculated
- how permissions are calculated

**This pull request also touches…**

hopefully nothing else.

- possible side effects of this change
- any authentication or permission changes are possible

**This pull request was tested in the follow ways…**

- adjusted the seed process to ensure no users have the "state admin" permission
- added some additional state certifications to the state admin user to make sure switching between admin and non admin states works as expected

**Steps to manually verify this change...**

1. log in as state admin -> you should have admin permissions
2. log in as state staff -> you should NOT have admin permissions
3. log in as other users and ensure accurate permissions


4. Log in as user (admin/not admin is unimportant)
5. switch to a state where you are an admin
6. ensure you have accurate permissions/activities   If you have staff permissions there is a problem

If you want to technically go through the DB and JWT please contact me and we can go over it.

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
