### PR TITLE
creating tokens for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ api/test-data/files
 notes.md
 schema.sql
 Makefile
+api/seeds/test/tokens.json
 
 # use npm to manage packages, not yarn
 api/yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Anticipated release: July 15, 2021
 - Upgrade Browser alert not showing up for IE11 ([#3272])
 
 #### ⚙️ Behind the scenes
+- created test tokens when database is seeded (development and test only) ([#3128]) 
 
 # Previous releases
 
 See our [release history](https://github.com/CMSgov/eAPD/releases)
 
+[#3i28]: https://github.com/CMSgov/eAPD/issues/3128
 [#3272]: https://github.com/CMSgov/eAPD/issues/3272

--- a/api/seeds/development/base-users.js
+++ b/api/seeds/development/base-users.js
@@ -1,7 +1,10 @@
 const { format } = require('date-fns')
+const fs = require('fs')
 const logger = require('../../logger')('user seeder');
 const { oktaClient } = require('../../auth/oktaAuth');
 const { createUsersToAdd } = require('../shared/set-up-users');
+const { issueTokens} = require('../shared/issueTokens')
+
 
 exports.seed = async knex => {
   const {oktaAffiliations, stateCertifications, oktaUsers} = await createUsersToAdd(knex, oktaClient);
@@ -19,5 +22,15 @@ exports.seed = async knex => {
   })
 
   await knex('state_admin_certifications_audit').insert(auditEntries)
+
+  const testTokens = await issueTokens(oktaUsers)
+
+  // save the tokens to a file
+  try {
+    fs.writeFileSync(`${__dirname  }/../test/tokens.json`, JSON.stringify(testTokens,null, 4))
+  } catch (err) {
+    // not much to do here but log it
+    console.error(err)
+  }
 
 };

--- a/api/seeds/shared/issueTokens.js
+++ b/api/seeds/shared/issueTokens.js
@@ -1,0 +1,19 @@
+const { getUserByID } = require('../../db');
+const {sign, getDefaultOptions} = require('../../auth/jwtUtils')
+
+const issueTokens = async (oktaUsers) => {
+  const response = {}
+  const defaultOptions = getDefaultOptions()
+  // bump that expiration date WAAAY up
+  defaultOptions.expiresIn = '365d'
+  await Promise.all(oktaUsers.map(async user =>{
+    const claims = await getUserByID(user.user_id, false, {})
+    response[user.login] = sign(claims, defaultOptions)
+  }));
+
+  return response
+}
+
+module.exports = {
+  issueTokens
+};

--- a/api/seeds/shared/set-up-users.js
+++ b/api/seeds/shared/set-up-users.js
@@ -80,7 +80,8 @@ const createUsersToAdd = async (knex, oktaClient) => {
       state_id: 'ak',
       role_id: stateAdminRoleId,
       status: 'approved',
-      updated_by: 'seeds'
+      updated_by: 'seeds',
+      username: 'em@il.com'
     });
     // Add an expired certification and this user will be downgraded to "regular user"
     stateCertifications.push({


### PR DESCRIPTION

resolves #3128

**Description-**

Adds a process to the seed method that produces a file called tokens.json that contains a long lived token for every seeded user.  This will allow the automated tests to use a current and valid token for auth which should greatly increase our confidence that tests are testing the right things.

**This pull request changes...**

- creates app/api/seeds/test/tokens.json when the seed process is run

**This pull request also touches…**

- nothibg else.  This does not touch code that runs except during the seed process

**This pull request was tested in the follow ways…**

- ran seed process
- opened tokens.json and verified them at jwt.io

**Steps to manually verify this change...**

1. execute the seed process
2. confirm tokens.json exists
3. validate tokens at jwt.io
4. confirm all expected users have a token

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
