### PR TITLE
Removed extraneous instances of 'another' from button text

### DIFF
--- a/web/src/components/SecondaryNav.js
+++ b/web/src/components/SecondaryNav.js
@@ -24,7 +24,7 @@ const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
             onClick={addActivity}
             className="ds-c-button"
           >
-            Add another activity
+            Add activity
           </Link>
         </div>
       )}

--- a/web/src/components/SecondaryNav.js
+++ b/web/src/components/SecondaryNav.js
@@ -24,7 +24,7 @@ const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
             onClick={addActivity}
             className="ds-c-button"
           >
-            Add activity
+            Add Activity
           </Link>
         </div>
       )}

--- a/web/src/containers/activity/All.js
+++ b/web/src/containers/activity/All.js
@@ -18,7 +18,7 @@ const All = ({ addActivity, activities }) => {
         <EntryDetails apdId={apdId} activityIndex={index} key={activity.key} />
       ))}
       <Button className="ds-u-margin-top--4" onClick={addActivity}>
-        Add another activity
+        Add activity
       </Button>
     </Section>
   );

--- a/web/src/containers/activity/All.js
+++ b/web/src/containers/activity/All.js
@@ -18,7 +18,7 @@ const All = ({ addActivity, activities }) => {
         <EntryDetails apdId={apdId} activityIndex={index} key={activity.key} />
       ))}
       <Button className="ds-u-margin-top--4" onClick={addActivity}>
-        Add activity
+        Add Activity
       </Button>
     </Section>
   );

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -39,7 +39,7 @@ const ContractorResources = ({
     >
       <FormAndReviewList
         activityIndex={activityIndex}
-        addButtonText="Add another contractor"
+        addButtonText="Add contractor"
         list={contractors}
         collapsed={ContractorResourceReview}
         expanded={ContractorResourceForm}

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -39,7 +39,7 @@ const ContractorResources = ({
     >
       <FormAndReviewList
         activityIndex={activityIndex}
-        addButtonText="Add contractor"
+        addButtonText="Add Contractor"
         list={contractors}
         collapsed={ContractorResourceReview}
         expanded={ContractorResourceForm}

--- a/web/src/containers/activity/Outcomes.js
+++ b/web/src/containers/activity/Outcomes.js
@@ -49,12 +49,12 @@ const Outcomes = ({
       <hr className="subsection-rule" />
       <FormAndReviewList
         activityIndex={activityIndex}
-        addButtonText="Add another outcome"
+        addButtonText="Add outcome"
         list={outcomes}
         collapsed={OutcomeAndMetricReview}
         expanded={OutcomeAndMetricForm}
         extraItemButtons={[
-          { onClick: handleAddMetric, text: 'Add another metric' }
+          { onClick: handleAddMetric, text: 'Add metric' }
         ]}
         removeMetric={handleDeleteMetric}
         noDataMessage={t('activities.outcomes.noDataNotice')}

--- a/web/src/containers/activity/Outcomes.js
+++ b/web/src/containers/activity/Outcomes.js
@@ -49,12 +49,12 @@ const Outcomes = ({
       <hr className="subsection-rule" />
       <FormAndReviewList
         activityIndex={activityIndex}
-        addButtonText="Add outcome"
+        addButtonText="Add Outcome"
         list={outcomes}
         collapsed={OutcomeAndMetricReview}
         expanded={OutcomeAndMetricForm}
         extraItemButtons={[
-          { onClick: handleAddMetric, text: 'Add metric' }
+          { onClick: handleAddMetric, text: 'Add Metric' }
         ]}
         removeMetric={handleDeleteMetric}
         noDataMessage={t('activities.outcomes.noDataNotice')}

--- a/web/src/containers/activity/__snapshots__/All.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/All.test.js.snap
@@ -29,7 +29,7 @@ exports[`the Activities component renders correctly 1`] = `
     onClick={[Function]}
     type="button"
   >
-    Add activity
+    Add Activity
   </Button>
 </Section>
 `;

--- a/web/src/containers/activity/__snapshots__/All.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/All.test.js.snap
@@ -29,7 +29,7 @@ exports[`the Activities component renders correctly 1`] = `
     onClick={[Function]}
     type="button"
   >
-    Add another activity
+    Add activity
   </Button>
 </Section>
 `;

--- a/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
@@ -9,7 +9,7 @@ exports[`the ContractorResources component renders correctly 1`] = `
 >
   <FormAndReviewList
     activityIndex={0}
-    addButtonText="Add another contractor"
+    addButtonText="Add contractor"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
@@ -9,7 +9,7 @@ exports[`the ContractorResources component renders correctly 1`] = `
 >
   <FormAndReviewList
     activityIndex={0}
-    addButtonText="Add contractor"
+    addButtonText="Add Contractor"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/Milestones.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Milestones.test.js.snap
@@ -13,7 +13,7 @@ exports[`the Milestones component renders correctly 1`] = `
     <hr />
     <FormAndReviewList
       activityIndex={7}
-      addButtonText="Add milestone"
+      addButtonText="Add Milestone"
       allowDeleteAll={true}
       className={null}
       collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/Milestones.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Milestones.test.js.snap
@@ -13,7 +13,7 @@ exports[`the Milestones component renders correctly 1`] = `
     <hr />
     <FormAndReviewList
       activityIndex={7}
-      addButtonText="Add another milestone"
+      addButtonText="Add milestone"
       allowDeleteAll={true}
       className={null}
       collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/NonPersonnelCosts.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/NonPersonnelCosts.test.js.snap
@@ -16,7 +16,7 @@ exports[`activity non-personnel costs subsection renders correctly 1`] = `
   />
   <FormAndReviewList
     activityIndex={58}
-    addButtonText="Add state expense"
+    addButtonText="Add State Expense"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/NonPersonnelCosts.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/NonPersonnelCosts.test.js.snap
@@ -16,7 +16,7 @@ exports[`activity non-personnel costs subsection renders correctly 1`] = `
   />
   <FormAndReviewList
     activityIndex={58}
-    addButtonText="Add another state expense"
+    addButtonText="Add state expense"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/Outcomes.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Outcomes.test.js.snap
@@ -12,7 +12,7 @@ exports[`activity Outcomes and Metrics component renders properly 1`] = `
   />
   <FormAndReviewList
     activityIndex={0}
-    addButtonText="Add another outcome"
+    addButtonText="Add outcome"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}
@@ -29,7 +29,7 @@ exports[`activity Outcomes and Metrics component renders properly 1`] = `
       Array [
         Object {
           "onClick": [Function],
-          "text": "Add another metric",
+          "text": "Add metric",
         },
       ]
     }

--- a/web/src/containers/activity/__snapshots__/Outcomes.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Outcomes.test.js.snap
@@ -12,7 +12,7 @@ exports[`activity Outcomes and Metrics component renders properly 1`] = `
   />
   <FormAndReviewList
     activityIndex={0}
-    addButtonText="Add outcome"
+    addButtonText="Add Outcome"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}
@@ -29,7 +29,7 @@ exports[`activity Outcomes and Metrics component renders properly 1`] = `
       Array [
         Object {
           "onClick": [Function],
-          "text": "Add metric",
+          "text": "Add Metric",
         },
       ]
     }

--- a/web/src/containers/activity/__snapshots__/StatePersonnel.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/StatePersonnel.test.js.snap
@@ -16,7 +16,7 @@ exports[`activity state personnel costs subsection renders correctly 1`] = `
   />
   <FormAndReviewList
     activityIndex={72}
-    addButtonText="Add state staff"
+    addButtonText="Add State Staff"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}

--- a/web/src/containers/activity/__snapshots__/StatePersonnel.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/StatePersonnel.test.js.snap
@@ -16,7 +16,7 @@ exports[`activity state personnel costs subsection renders correctly 1`] = `
   />
   <FormAndReviewList
     activityIndex={72}
-    addButtonText="Add another state staff"
+    addButtonText="Add state staff"
     allowDeleteAll={true}
     className={null}
     collapsed={[Function]}

--- a/web/src/i18n/locales/en/activities/expenses.yaml
+++ b/web/src/i18n/locales/en/activities/expenses.yaml
@@ -8,4 +8,4 @@ instruction:
     materials and supplies, communications‐related expenses, printing costs and
     facilities expenses.
 noDataNotice: Other state expenses have not been added for this activity.
-addButtonText: Add another state expense
+addButtonText: Add state expense

--- a/web/src/i18n/locales/en/activities/expenses.yaml
+++ b/web/src/i18n/locales/en/activities/expenses.yaml
@@ -8,4 +8,4 @@ instruction:
     materials and supplies, communications‐related expenses, printing costs and
     facilities expenses.
 noDataNotice: Other state expenses have not been added for this activity.
-addButtonText: Add state expense
+addButtonText: Add State Expense

--- a/web/src/i18n/locales/en/activities/milestones.yaml
+++ b/web/src/i18n/locales/en/activities/milestones.yaml
@@ -4,4 +4,4 @@ instruction:
     List major milestones the state is working toward as part of this
     activity. Include work occurring under previously approved APDs.
 noMilestonesNotice: Milestones have not been added for this activity.
-addMilestoneButtonText: Add another milestone
+addMilestoneButtonText: Add milestone

--- a/web/src/i18n/locales/en/activities/milestones.yaml
+++ b/web/src/i18n/locales/en/activities/milestones.yaml
@@ -4,4 +4,4 @@ instruction:
     List major milestones the state is working toward as part of this
     activity. Include work occurring under previously approved APDs.
 noMilestonesNotice: Milestones have not been added for this activity.
-addMilestoneButtonText: Add milestone
+addMilestoneButtonText: Add Milestone

--- a/web/src/i18n/locales/en/activities/statePersonnel.yaml
+++ b/web/src/i18n/locales/en/activities/statePersonnel.yaml
@@ -19,4 +19,4 @@ labels:
   costAmt: Cost with Benefits
   costPerc: Number of FTEs
 removeLabel: Remove personnel
-addButtonText: Add another state staff
+addButtonText: Add state staff

--- a/web/src/i18n/locales/en/activities/statePersonnel.yaml
+++ b/web/src/i18n/locales/en/activities/statePersonnel.yaml
@@ -19,4 +19,4 @@ labels:
   costAmt: Cost with Benefits
   costPerc: Number of FTEs
 removeLabel: Remove personnel
-addButtonText: Add state staff
+addButtonText: Add State Staff

--- a/web/src/i18n/locales/en/apd/stateProfile.yaml
+++ b/web/src/i18n/locales/en/apd/stateProfile.yaml
@@ -51,9 +51,9 @@ keyPersonnel:
     primary: 'This person is the primary APD point of contact:'
     hasCosts: Does this person have costs directly attributable to this program?
     addButton:
-      zero: Add key personnel
-      one: Add person
-      other: Add person
+      zero: Add Key Personnel
+      one: Add Person
+      other: Add Person
   delete:
     text: Remove contact
     confirm:

--- a/web/src/i18n/locales/en/apd/stateProfile.yaml
+++ b/web/src/i18n/locales/en/apd/stateProfile.yaml
@@ -52,8 +52,8 @@ keyPersonnel:
     hasCosts: Does this person have costs directly attributable to this program?
     addButton:
       zero: Add key personnel
-      one: Add another person
-      other: Add another person
+      one: Add person
+      other: Add person
   delete:
     text: Remove contact
     confirm:


### PR DESCRIPTION
resolves #3009 

**Description-**
Removes the word 'additional' from button label text from buttons in the key personnel and activities pages when editing an APD.

**This pull request changes...**

- Removes the word 'another' from button label text in:
  - Activities dashboard
  - Pages for editing activities
    - Outcomes and milestones
    - State staff and expenses
    - Private contractor costs
    - Budget and FFP

**This pull request also touches…**

- May affect tests done for the activities/key personnel pages if tests look for specific text for the buttons

**This pull request was tested in the follow ways…**

- Going to the pages containing the button with edited text and verifying that the word 'another' is no longer present

**Steps to manually verify this change...**

1. Log in and access APD
2. Navigate to the activities dashboard
3. Confirm that button says 'Add activity' instead of 'Add another activity'
3. Edit an existing activity or create a new activity and edit the new activity
4. Confirm that none of the buttons in the pages for editing the activity have 'additional' in their label
5. Navigate to key personnel page
6. Confirm that none of the buttons have 'additional' in their label

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [X] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [X] QA has verified the accessibility and functionality related to the change
- [X] Design has approved the experience
- [ ] Product has approved the experience
