### PR TITLE
tbolt/3334 Fixes issue where add activity would take you to another apd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Anticipated release: July 26, 2021
 
 #### 🐛 Bugs fixed
 
+- "Add Activity" button in activity page links to wrong APD ([#3334])
+
 #### ⚙️ Behind the scenes
 
 - updated APD seed data used for testing ([#2863])
@@ -27,3 +29,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#3226]: https://github.com/CMSgov/eAPD/issues/3226
 [#3246]: https://github.com/CMSgov/eAPD/issues/3246
 [#3264]: https://github.com/CMSgov/eAPD/issues/3264
+[#3334]: https://github.com/CMSgov/eAPD/issues/3334

--- a/web/src/components/SecondaryNav.js
+++ b/web/src/components/SecondaryNav.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, useParams as actualUseParams } from 'react-router-dom';
 import ContinuePreviousButtons from './ContinuePreviousButtons';
+
 import {
   selectActivitiesSidebar,
   selectActivityCount
@@ -11,6 +12,8 @@ import { addActivity as actualAddActivity } from '../actions/editActivity';
 
 const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
   const { activityIndex } = useParams();
+  const apdId = +useParams().apdId;
+
   const showAddActivityLink =
     Number(activityIndex) + 1 === activityCount &&
     location.pathname.endsWith('ffp');
@@ -20,7 +23,7 @@ const SecondaryNav = ({ activityCount, addActivity, location, useParams }) => {
       {showAddActivityLink && (
         <div className="pre-button-section-break">
           <Link
-            to="/apd/1/activities"
+            to={`/apd/${apdId}/activities`}
             onClick={addActivity}
             className="ds-c-button"
           >

--- a/web/src/components/SecondaryNav.test.js
+++ b/web/src/components/SecondaryNav.test.js
@@ -41,7 +41,7 @@ describe('Secondary Nav component', () => {
   it('handles add activity button click', () => {
     const component = setup();
     const link = component.find('.ds-c-button');
-    expect(link.props().to).toBe('/apd/1/activities');
+    expect(link.props().to).toBe(`/apd/${defaultProps.useParams().apdId}/activities`);
 
     link.simulate('click');
 


### PR DESCRIPTION
resolves #3334 

**Description-**

**This pull request changes...**

- Fixes an issue where the add activity button (the one that was at the bottom of the last activity) was hard-coded to take you to the APD with ID = 1

**This pull request also touches…**

- no side-effects noted

**This pull request was tested in the follow ways…**

- test using the add activity button with an existing APD
- test using the add activity button with a newly created APD

**Steps to manually verify this change...**

1. Login with an account that can view/edit APDs
2. Navigate to the last activity on the Budget and FFP page
3. Click Add activity
4. Verify that it takes you to the Activities Dashboard and creates a new Activity

### This pull request is ready to review when...

- [x] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
