### PR TITLE
tbolt/3338 Fix bug with activity summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Anticipated release: July 26, 2021
 
 #### 🐛 Bugs fixed
 
+- Activity Summary displaying incorrectly in Executive Summary ([#3338])
+
 #### ⚙️ Behind the scenes
 
 - updated APD seed data used for testing ([#2863])
@@ -27,3 +29,4 @@ See our [release history](https://github.com/CMSgov/eAPD/releases)
 [#3226]: https://github.com/CMSgov/eAPD/issues/3226
 [#3246]: https://github.com/CMSgov/eAPD/issues/3246
 [#3264]: https://github.com/CMSgov/eAPD/issues/3264
+[#3338]: https://github.com/CMSgov/eAPD/issues/3338

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -38,7 +38,10 @@ const ExecutiveSummary = ({ data, total, years }) => {
               editHref={`/apd/${apdId}/activity/${i}/overview`}
               className={i === data.length - 1 ? 'ds-u-border-bottom--0' : ''}
             >
-              {activity.summary && <p>{activity.summary}</p>}
+              {activity.summary && (
+                /* eslint-disable react/no-danger */
+                <p dangerouslySetInnerHTML={{ __html: activity.summary }} />
+              )}
               <ul className="ds-c-list--bare">
                 <li>
                   <strong>Start date - End date:</strong> {activity.dateRange}

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -35,9 +35,13 @@ exports[`executive summary component renders correctly 1`] = `
         onEditClick={null}
         title={null}
       >
-        <p>
-          first activity
-        </p>
+        <p
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "first activity",
+            }
+          }
+        />
         <ul
           className="ds-c-list--bare"
         >
@@ -147,9 +151,13 @@ exports[`executive summary component renders correctly 1`] = `
         onEditClick={null}
         title={null}
       >
-        <p>
-          second activity
-        </p>
+        <p
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "second activity",
+            }
+          }
+        />
         <ul
           className="ds-c-list--bare"
         >


### PR DESCRIPTION
resolves #3338 

**Description-**

**This pull request changes...**

- Updates the Activity Summary on the Executive Summary page to properly render HTML
- No side effects expected

**This pull request was tested in the follow ways…**

- Add richly-formatted text (bold text, image, etc...) to any Activity Summary
- Verify that when viewing the previously entered activity summary on the executive summary page it's rendering properly and not displaying html tags (such as `<p>` or `<strong>`)

**Steps to manually verify this change...**

1. Login with any user that can view APDs
2. Navigate to an activities activity overview page
3. Enter some richly-formatted text such as **bold**
4. Verify that in the executive summary it is rendering properly and not displaying html tags

### This pull request is ready to review when...

- [x] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
