### PR TITLE
Hygen template for adding in an API endpoint

### DIFF
--- a/_templates/routes/new/prompt.js
+++ b/_templates/routes/new/prompt.js
@@ -1,0 +1,14 @@
+module.exports = [
+  {
+    type: 'select',
+    choices: ["get", "post", "put", "patch", "delete"],
+    name: 'httpVerb',
+    message: "What http verb is this route for?"
+  },
+  {
+    type: 'input',
+    name: 'httpPath',
+    message: "What is the path for this endpoint (foo/bar)"
+  },
+
+]

--- a/_templates/routes/new/routes/index.import.js.ejs.t
+++ b/_templates/routes/new/routes/index.import.js.ejs.t
@@ -1,0 +1,6 @@
+---
+inject: true
+to: api/routes/index.js
+before: ROUTE IMPORT INSERTION POINT
+---
+const <%= httpVerb %><%= h.changeCase.pascalCase(httpPath.replace('/', ' ')) %> = require('./<%= httpPath %>/<%= httpVerb %>');

--- a/_templates/routes/new/routes/index.registration.js.ejs.t
+++ b/_templates/routes/new/routes/index.registration.js.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: api/routes/index.js
+before: ROUTE REGISTRATION INSERTION POINT
+---
+  logger.debug('setting up routes for <%=httpVerb %> <%=httpPath %>');
+  <%= httpVerb %><%= h.changeCase.pascalCase(httpPath.replace('/', ' ')) %>(app);

--- a/_templates/routes/new/routes/openApi/openApi.import.js.ejs.t
+++ b/_templates/routes/new/routes/openApi/openApi.import.js.ejs.t
@@ -1,0 +1,6 @@
+---
+inject: true
+to: api/routes/openApi/index.js
+before: OPENAPI IMPORT INSERTION POINT
+---
+const <%= httpVerb %><%= h.changeCase.pascalCase(httpPath.replace('/', ' ')) %> = require('../<%= httpPath %>/<%= httpVerb %>OpenApi');

--- a/_templates/routes/new/routes/openApi/openApi.paths.js.ejs.t
+++ b/_templates/routes/new/routes/openApi/openApi.paths.js.ejs.t
@@ -1,0 +1,6 @@
+---
+inject: true
+to: api/routes/openApi/index.js
+before: OPENAPI PATH INSERTION POINT
+---
+    ...<%= httpVerb %><%= h.changeCase.pascalCase(httpPath.replace('/', ' ')) %>,

--- a/_templates/routes/new/routes/path/path.verb.endpoint.js.ejs.t
+++ b/_templates/routes/new/routes/path/path.verb.endpoint.js.ejs.t
@@ -1,0 +1,20 @@
+---
+to: api/routes/<%= httpPath %>/<%= httpVerb %>.endpoint.js
+---
+const {
+  login,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../../endpoint-tests/utils');
+
+
+describe('<%= httpVerb.upperCase %> /<%= httpPath %>', () => {
+    unauthenticatedTest('get', '/<%= httpPath %>');
+    unauthorizedTest('get', '/<%= httpPath %>');
+
+    it('returns 200', async () => {
+      const api = login('all-permissions');
+      const response = await api.<%= httpVerb %>('/<%= httpPath %>');
+      expect(response.status).toEqual(200);
+    });
+})

--- a/_templates/routes/new/routes/path/path.verb.js.ejs.t
+++ b/_templates/routes/new/routes/path/path.verb.js.ejs.t
@@ -1,0 +1,33 @@
+---
+to: api/routes/<%= httpPath %>/<%= httpVerb %>.js
+---
+
+const { loggedIn } = require('../../../middleware/auth');
+// const { can } = require('../../../middleware');
+const logger = require('../../../logger')('<%= httpPath %> <%= httpVerb %>');
+
+module.exports = (
+  app,
+  {
+
+    // add direct injections here
+  } = {}
+) => {
+  logger.silly('setting up <%= httpVerb.toUpperCase() %> /<%= httpPath %> route');
+
+  app.<%= httpVerb %>(
+    '/<%= httpPath %>',
+    loggedIn,
+    // can('foo')
+    async (req, res, next) => {
+      try {
+        const result = {result: 'success'}
+        res.send(result);
+      } catch (e) {
+        logger.error({ id: req.id, message: 'change me' });
+        logger.error({ id: req.id, message: e });
+        next({ message: 'change me' });
+      }
+    }
+  );
+};

--- a/_templates/routes/new/routes/path/path.verb.test.ejs.t
+++ b/_templates/routes/new/routes/path/path.verb.test.ejs.t
@@ -1,0 +1,52 @@
+---
+to: api/routes/<%= httpPath %>/<%= httpVerb %>.test.js
+---
+const tap = require('tap');
+const sinon = require('sinon');
+const <%=httpVerb %>Endpoint = require('./<%=httpVerb %>');
+
+const mockExpress = require('../../util/mockExpress');
+const mockResponse = require('../../util/mockResponse');
+
+let app;
+let res;
+let next;
+
+
+tap.test('<%= httpPath %> <%=httpVerb.toUpperCase() %> endpoint', async endpointTest => {
+  endpointTest.beforeEach(async () => {
+    app = mockExpress();
+    res = mockResponse();
+    next = sinon.stub();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    getEndpoint(app);
+
+    setupTest.ok(
+      app.<%= httpVerb %>.calledWith('/<%= httpPath %>', sinon.match.func),
+      '<%= httpPath %> <%= httpVerb.toUpperCase() %> endpoint is registered'
+    );
+  });
+
+  endpointTest.test('<%=httpVerb %> <%=httpPath %> handler', async tests => {
+    let handler;
+
+    tests.beforeEach(async () => {
+      <%= httpVerb %>Endpoint(app, { });
+      handler = app.<%= httpVerb %>.args.find(
+        args => args[0] === '/<%= httpPath %>'
+      ).pop();
+    });
+
+    tests.test('basic handler test', async test => {
+        const req = {}
+        await handler(req, res, next);
+        test.ok(res.send.calledWith({result: 'success'}))
+    })
+
+  });
+
+
+
+});

--- a/_templates/routes/new/routes/path/verbOpenApi.js.ejs.t
+++ b/_templates/routes/new/routes/path/verbOpenApi.js.ejs.t
@@ -1,0 +1,35 @@
+---
+to: api/routes/<%= httpPath %>/<%= httpVerb %>OpenApi.js
+---
+const {
+  requiresAuth,
+  schema: { jsonResponse }
+} = require('../../openAPI/helpers');
+
+const responseObj = jsonResponse({
+  type: 'object',
+  properties: {
+    result: {
+      type: 'string',
+      description: `template generated description`
+    },
+  }
+});
+
+const <%= httpVerb %><%= h.changeCase.pascalCase(httpPath.replace('/', ' ')) %> = {
+  '/<%= httpPath %>': {
+    <%= httpVerb%>: {
+      tags: [],
+      summary: `Template generated summary`,
+      description: `template generated description`,
+      responses: {
+        200: {
+          description: 'response description',
+          content: responseObj
+        }
+      }
+    }
+  }
+};
+
+module.exports = requiresAuth(<%= httpVerb %><%= h.changeCase.pascalCase(httpPath.replace('/', ' ')) %>);

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -9,6 +9,7 @@ const states = require('./states');
 const users = require('./users');
 const openAPI = require('./openAPI');
 
+// ############### ROUTE IMPORT INSERTION POINT #######################
 module.exports = (
   app,
   affiliationsEndpoint = affiliations,
@@ -20,7 +21,7 @@ module.exports = (
   usersEndpoint = users,
   openAPIdoc = openAPI
 ) => {
-  logger.debug('setting up routes for affilitions');
+  logger.debug('setting up routes for affiliations');
   affiliationsEndpoint(app);
   logger.debug('setting up routes for apds');
   apdsEndpoint(app);
@@ -35,6 +36,7 @@ module.exports = (
   logger.debug('setting up routes for users');
   usersEndpoint(app);
 
+  // ############### ROUTE REGISTRATION INSERTION POINT #######################
   logger.debug('setting up route for OpenAPI');
 
   app.get('/open-api', (req, res) => {

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -10,6 +10,8 @@ const me = require('../me/openAPI');
 const roles = require('../roles/openAPI');
 const states = require('../states/openAPI');
 const users = require('../users/openAPI');
+
+// ############## OPENAPI IMPORT INSERTION POINT ######################
 const { arrayOf } = require('./helpers').schema;
 
 module.exports = {
@@ -30,6 +32,8 @@ module.exports = {
     ...roles,
     ...states,
     ...users,
+
+    // ############## OPENAPI PATH INSERTION POINT ######################
     '/open-api': {
       get: {
         tags: ['Metadata'],


### PR DESCRIPTION

**Description-**
THis adds hygen templates for creating an api endpoint and all associated files.  I can write a doc, but I think a demo would be easier.
**This pull request changes...**

- adds a hygen template to help speed development

**This pull request also touches…**

- none, this does not involve any running code.

**This pull request was tested in the follow ways…**

- list of frontend cases
- list of backend cases

**Steps to manually verify this change...**

1. install hygen according to the directions at hygen.io
2. in the eAPD root directory run "hygen routes new" and answer the prompts
3. run unit and endpoint tests.  (you may need to adjust the path of some imports, but that is just a matter of more (or less) "../" in the path.  This can be fixed but the library name is "sexy-paths" and I don't know how I feel about that.
4. change the endpoint in any way that makes sense for your needs.
5. 

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
