### PR TITLE
bbrooks/3672-Patch-On-Boot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,6 +682,9 @@ jobs:
                 --MONGO_URL "$PREVIEW_MONGO_URL" 
               )
               ./github-comment.sh "$PRNUM" "https://$URL" "$CIRCLE_SHA1"
+              echo $PRNUM
+              echo $URL
+              echo $CIRCLE_SHA1
             else
               echo "Not a pull request"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,6 +682,9 @@ jobs:
                 --MONGO_URL "$PREVIEW_MONGO_URL" 
               )
               ./github-comment.sh "$PRNUM" "https://$URL" "$CIRCLE_SHA1"
+              echo PRNUM is $PRNUM
+              echo URL is $URL
+              echo SHA is $CIRCLE_SHA1
             else
               echo "Not a pull request"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,9 +682,6 @@ jobs:
                 --MONGO_URL "$PREVIEW_MONGO_URL" 
               )
               ./github-comment.sh "$PRNUM" "https://$URL" "$CIRCLE_SHA1"
-              echo $PRNUM
-              echo $URL
-              echo $CIRCLE_SHA1
             else
               echo "Not a pull request"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -682,9 +682,6 @@ jobs:
                 --MONGO_URL "$PREVIEW_MONGO_URL" 
               )
               ./github-comment.sh "$PRNUM" "https://$URL" "$CIRCLE_SHA1"
-              echo PRNUM is $PRNUM
-              echo URL is $URL
-              echo SHA is $CIRCLE_SHA1
             else
               echo "Not a pull request"
             fi

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -80,6 +80,9 @@ function deployPreviewtoEC2() {
     print "Environment $ENVIRONMENT is invalid"
   fi
 
+  print "• Applying CMS Patches"
+  aws ssm send-command --instance-ids "$INSTANCE_ID" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance"
+
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
     terminateInstance "$INSTANCE_ID"
@@ -164,7 +167,6 @@ function createNewInstance() {
     --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}},{Key=cms-cloud-exempt:open-sg,Value=CLDSPT-5877}]" \
     --user-data file://aws.user-data.sh \
     --key-name eapd_bbrooks \
-    --iam-instance-profile "EnablesEC2ToAccessSystemsManagerRole" \
     | jq -r -c '.Instances[0].InstanceId'
 }
 
@@ -240,7 +242,6 @@ function waitForInstanceToBeReady() {
     INSTANCE_CHECK_COUNT=$((INSTANCE_CHECK_COUNT+1))
   done
   print "  ...status check #$INSTANCE_CHECK_COUNT: READY"
-  aws ssm send-command --instance-ids "$1" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance"
 }
 
 # Iterate while there are arguments

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -82,7 +82,7 @@ function deployPreviewtoEC2() {
 
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets "[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]" \
+    --targets '[{\"Key\":\"InstanceIds\",\"Values\":[\"$INSTANCE_ID\"]}]' \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
 

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -48,7 +48,7 @@ function deployPreviewtoEC2() {
   # Create new EC2 instance
   print "• Creating EC2 instance"
   INSTANCE_ID=$(createNewInstance $AMI_ID)
-  print "• Created instance $INSTANCE_ID"
+  print "  ...Created instance $INSTANCE_ID"
 
   # Wait for the instance to become ready.  This will happen once the VM is
   # networkically available, which isn't strictly useful to us, but it's as
@@ -59,7 +59,7 @@ function deployPreviewtoEC2() {
   print "• Getting public DNS name of new instance"
   associateElasticIP "$INSTANCE_ID"
   PUBLIC_DNS=$(getPublicDNS "$INSTANCE_ID")
-  print "• Public address: $PUBLIC_DNS"
+  print "  ...Public address: $PUBLIC_DNS"
 
   print "• Checking availability of Frontend"
   ENVIRONMENT="test"
@@ -67,6 +67,7 @@ function deployPreviewtoEC2() {
     while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://$PUBLIC_DNS)" != "200" ]]; 
       do print "  ...Frontend currently unavailable" && sleep 60; 
     done
+    print "  ...Frontend is available"
   else
     print "Environment $ENVIRONMENT is invalid"
   fi
@@ -76,6 +77,7 @@ function deployPreviewtoEC2() {
     while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://$PUBLIC_DNS/api/heartbeat)" != "204" ]]; 
       do print "  ...Backend currently unavailable" && sleep 60; 
     done
+    print "  ...Backend is available"
   else
     print "Environment $ENVIRONMENT is invalid"
   fi
@@ -249,7 +251,8 @@ function applyCMSPatches() {
     --targets Key=instanceids,Values=$1 \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
-    > /dev/null    
+    > /dev/null
+  print "  ...patches applied"
 }
 
 # Iterate while there are arguments

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -92,6 +92,9 @@ function deployPreviewtoEC2() {
   done <<< "$EXISTING_INSTANCES"
 
   echo "$PUBLIC_DNS"
+
+  print "• Applying CMS Patches"
+  applyCMSPatches "$INSTANCE_ID"
 }
 
 # Sets up AWS global configuration for all subsequent commands.
@@ -247,6 +250,15 @@ function waitForInstanceToBeReady() {
   print "  ...status check #$INSTANCE_CHECK_COUNT: READY"
 }
 
+function applyCMSPatches() {
+
+  print "• Applying CMS Patches"
+  aws ssm send-command \
+    --targets Key=instanceids,Values=$1 \
+    --document-name "AWS-RunPatchBaseline" \
+    --comment "CMS Patch Compliance"
+}
+
 # Iterate while there are arguments
 while [ $# -gt 0 ]; do
   # If the argument begins with --, strip the -- to create the variable name
@@ -261,9 +273,3 @@ while [ $# -gt 0 ]; do
 done
 
 echo "$(deployPreviewtoEC2)"
-
-  print "• Applying CMS Patches"
-  aws ssm send-command \
-    --targets Key=instanceids,Values=$INSTANCE_ID \
-    --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -81,10 +81,10 @@ function deployPreviewtoEC2() {
   fi
 
   print "• Applying CMS Patches"
-  $(aws ssm send-command \
+  aws ssm send-command \
     --targets "[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]" \
     --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance)
+    --comment "CMS Patch Compliance
 
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -56,12 +56,6 @@ function deployPreviewtoEC2() {
   print "• Waiting for instance to be ready"
   waitForInstanceToBeReady "$INSTANCE_ID"
 
-  print "• Applying CMS Patches"
-  aws ssm send-command \
-    --targets Key=instanceids,Values=$INSTANCE_ID \
-    --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"
-
   print "• Getting public DNS name of new instance"
   associateElasticIP "$INSTANCE_ID"
   PUBLIC_DNS=$(getPublicDNS "$INSTANCE_ID")
@@ -92,6 +86,12 @@ function deployPreviewtoEC2() {
   done <<< "$EXISTING_INSTANCES"
 
   echo "$PUBLIC_DNS"
+  
+  print "• Applying CMS Patches"
+  aws ssm send-command \
+    --targets Key=instanceids,Values=$INSTANCE_ID \
+    --document-name "AWS-RunPatchBaseline" \
+    --comment "CMS Patch Compliance"
 }
 
 # Sets up AWS global configuration for all subsequent commands.

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -65,7 +65,7 @@ function deployPreviewtoEC2() {
   ENVIRONMENT="test"
   if [[ $ENVIRONMENT == "test" ]]; then
     while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://$PUBLIC_DNS)" != "200" ]]; 
-      do print "• • Frontend currently unavailable" && sleep 60; 
+      do print "  ...Frontend currently unavailable" && sleep 60; 
     done
   else
     print "Environment $ENVIRONMENT is invalid"
@@ -74,19 +74,18 @@ function deployPreviewtoEC2() {
   print "• Checking availability of Backend"
   if [[ $ENVIRONMENT == "test" ]]; then
     while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://$PUBLIC_DNS/api/heartbeat)" != "204" ]]; 
-      do print "• • Backend currently unavailable" && sleep 60; 
+      do print "  ...Backend currently unavailable" && sleep 60; 
     done
   else
     print "Environment $ENVIRONMENT is invalid"
   fi
 
   print "• Applying CMS Patches"
-  sh '''
   aws ssm send-command \
-    --targets '[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]' \
+    --targets "Key=InstanceIds","Values=$INSTANCE_ID" \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
-  '''
+  
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
     terminateInstance "$INSTANCE_ID"

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -249,6 +249,7 @@ function applyCMSPatches() {
     --targets Key=instanceids,Values=$1 \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
+    > /dev/null    
 }
 
 # Iterate while there are arguments

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -239,7 +239,7 @@ function waitForInstanceToBeReady() {
     INSTANCE_CHECK_COUNT=$((INSTANCE_CHECK_COUNT+1))
   done
   print "  ...status check #$INSTANCE_CHECK_COUNT: READY"
-  aws ssm send-command --instance-ids "$1" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance"
+  aws ssm send-command --instance-ids "$1" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance" --iam-instance-profile "EnablesEC2ToAccessSystemsManagerRole"
 }
 
 # Iterate while there are arguments

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -264,6 +264,6 @@ echo "$(deployPreviewtoEC2)"
 
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets Key=instanceids,Values=$1 \
+    --targets Key=instanceids,Values=$INSTANCE_ID \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -56,14 +56,9 @@ function deployPreviewtoEC2() {
   print "• Waiting for instance to be ready"
   waitForInstanceToBeReady "$INSTANCE_ID"
 
-  print "• Addint IAM Role to new instance"
-  aws ec2 associate-iam-instance-profile \
-    --instance-id $INSTANCE_ID \
-    --iam-instance-profile Name="CCSPatchRole"
-
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets "Key=instanceids,Values=$INSTANCE_ID" \
+    --targets Key=instanceids,Values=$INSTANCE_ID \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
 

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -56,6 +56,12 @@ function deployPreviewtoEC2() {
   print "• Waiting for instance to be ready"
   waitForInstanceToBeReady "$INSTANCE_ID"
 
+  print "• Applying CMS Patches"
+  aws ssm send-command \
+    --targets "Key=instanceids,Values=$INSTANCE_ID" \
+    --document-name "AWS-RunPatchBaseline" \
+    --comment "CMS Patch Compliance"
+
   print "• Getting public DNS name of new instance"
   associateElasticIP "$INSTANCE_ID"
   PUBLIC_DNS=$(getPublicDNS "$INSTANCE_ID")
@@ -80,12 +86,6 @@ function deployPreviewtoEC2() {
     print "Environment $ENVIRONMENT is invalid"
   fi
 
-  print "• Applying CMS Patches"
-  aws ssm send-command \
-    --targets "Key=instanceids,Values=$INSTANCE_ID" \
-    --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"
-  
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
     terminateInstance "$INSTANCE_ID"

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -164,6 +164,7 @@ function createNewInstance() {
     --tag-specification "ResourceType=instance,Tags=[{Key=Name,Value=eAPD PR $PR_NUM},{Key=environment,Value=preview},{Key=github-pr,Value=${PR_NUM}},{Key=cms-cloud-exempt:open-sg,Value=CLDSPT-5877}]" \
     --user-data file://aws.user-data.sh \
     --key-name eapd_bbrooks \
+    --iam-instance-profile "EnablesEC2ToAccessSystemsManagerRole" \
     | jq -r -c '.Instances[0].InstanceId'
 }
 
@@ -239,7 +240,7 @@ function waitForInstanceToBeReady() {
     INSTANCE_CHECK_COUNT=$((INSTANCE_CHECK_COUNT+1))
   done
   print "  ...status check #$INSTANCE_CHECK_COUNT: READY"
-  aws ssm send-command --instance-ids "$1" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance" --iam-instance-profile "EnablesEC2ToAccessSystemsManagerRole"
+  aws ssm send-command --instance-ids "$1" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance"
 }
 
 # Iterate while there are arguments

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -250,7 +250,7 @@ function applyCMSPatches() {
   aws ssm send-command \
     --targets Key=instanceids,Values=$1 \
     --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"
+    --comment "CMS Patch Compliance" \
     > /dev/null
   print "  ...patches applied"
 }

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -80,11 +80,11 @@ function deployPreviewtoEC2() {
     print "Environment $ENVIRONMENT is invalid"
   fi
 
-  print "• Applying CMS Patches"
-  aws ssm send-command \
-    --targets Key=instanceids,Values=$INSTANCE_ID \
-    --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"
+#  print "• Applying CMS Patches"
+#  aws ssm send-command \
+#    --targets Key=instanceids,Values=$INSTANCE_ID \
+#    --document-name "AWS-RunPatchBaseline" \
+#    --comment "CMS Patch Compliance"
 
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
@@ -261,3 +261,9 @@ while [ $# -gt 0 ]; do
 done
 
 echo "$(deployPreviewtoEC2)"
+
+  print "• Applying CMS Patches"
+  aws ssm send-command \
+    --targets Key=instanceids,Values=$1 \
+    --document-name "AWS-RunPatchBaseline" \
+    --comment "CMS Patch Compliance"

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -81,10 +81,10 @@ function deployPreviewtoEC2() {
   fi
 
   print "• Applying CMS Patches"
-  aws ssm send-command \
-    --targets "[{\"Key\":\"InstanceIds\",\"Values\":[\"$INSTANCE_ID\"]}]" \
+  $(aws ssm send-command \
+    --targets "[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]" \
     --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"
+    --comment "CMS Patch Compliance)
 
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -82,7 +82,7 @@ function deployPreviewtoEC2() {
 
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets "Key=InstanceIds","Values=$INSTANCE_ID" \
+    --targets "Key=InstanceIds,Values=$INSTANCE_ID" \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
   

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -56,6 +56,11 @@ function deployPreviewtoEC2() {
   print "• Waiting for instance to be ready"
   waitForInstanceToBeReady "$INSTANCE_ID"
 
+  print "• Addint IAM Role to new instance"
+  aws ec2 associate-iam-instance-profile \
+    --instance-id $INSTANCE_ID \
+    --iam-instance-profile Name="CCSPatchRole"
+
   print "• Applying CMS Patches"
   aws ssm send-command \
     --targets "Key=instanceids,Values=$INSTANCE_ID" \

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -80,18 +80,18 @@ function deployPreviewtoEC2() {
     print "Environment $ENVIRONMENT is invalid"
   fi
 
+  print "• Applying CMS Patches"
+  aws ssm send-command \
+    --targets Key=instanceids,Values=$INSTANCE_ID \
+    --document-name "AWS-RunPatchBaseline" \
+    --comment "CMS Patch Compliance"
+
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
     terminateInstance "$INSTANCE_ID"
   done <<< "$EXISTING_INSTANCES"
 
   echo "$PUBLIC_DNS"
-  
-  print "• Applying CMS Patches"
-  aws ssm send-command \
-    --targets Key=instanceids,Values=$INSTANCE_ID \
-    --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance"
 }
 
 # Sets up AWS global configuration for all subsequent commands.

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -81,7 +81,10 @@ function deployPreviewtoEC2() {
   fi
 
   print "• Applying CMS Patches"
-  aws ssm send-command --instance-ids "$INSTANCE_ID" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance"
+  aws ssm send-command \
+    --targets '[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]' \
+    --document-name "AWS-RunPatchBaseline" \
+    --comment "CMS Patch Compliance"
 
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -82,7 +82,7 @@ function deployPreviewtoEC2() {
 
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets '[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]' \
+    --targets "[{'Key':'InstanceIds','Values':['$INSTANCE_ID']}]" \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
 

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -80,11 +80,8 @@ function deployPreviewtoEC2() {
     print "Environment $ENVIRONMENT is invalid"
   fi
 
-#  print "• Applying CMS Patches"
-#  aws ssm send-command \
-#    --targets Key=instanceids,Values=$INSTANCE_ID \
-#    --document-name "AWS-RunPatchBaseline" \
-#    --comment "CMS Patch Compliance"
+  print "• Applying CMS Patches"
+  applyCMSPatches "$INSTANCE_ID"
 
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
@@ -92,9 +89,6 @@ function deployPreviewtoEC2() {
   done <<< "$EXISTING_INSTANCES"
 
   echo "$PUBLIC_DNS"
-
-  print "• Applying CMS Patches"
-  applyCMSPatches "$INSTANCE_ID"
 }
 
 # Sets up AWS global configuration for all subsequent commands.

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -81,11 +81,12 @@ function deployPreviewtoEC2() {
   fi
 
   print "• Applying CMS Patches"
+  sh '''
   aws ssm send-command \
-    --targets '[{\"Key\":\"InstanceIds\",\"Values\":[\"$INSTANCE_ID\"]}]' \
+    --targets '[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]' \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
-
+  '''
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do
     terminateInstance "$INSTANCE_ID"

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -245,8 +245,6 @@ function waitForInstanceToBeReady() {
 }
 
 function applyCMSPatches() {
-
-  print "• Applying CMS Patches"
   aws ssm send-command \
     --targets Key=instanceids,Values=$1 \
     --document-name "AWS-RunPatchBaseline" \

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -82,7 +82,7 @@ function deployPreviewtoEC2() {
 
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets "[{'Key':'InstanceIds','Values':['$INSTANCE_ID']}]" \
+    --targets "[{\"Key\":\"InstanceIds\",\"Values\":[\"$INSTANCE_ID\"]}]" \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
 

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -82,7 +82,7 @@ function deployPreviewtoEC2() {
 
   print "• Applying CMS Patches"
   aws ssm send-command \
-    --targets "Key=InstanceIds,Values=$INSTANCE_ID" \
+    --targets "Key=instanceids,Values=$INSTANCE_ID" \
     --document-name "AWS-RunPatchBaseline" \
     --comment "CMS Patch Compliance"
   

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -239,6 +239,7 @@ function waitForInstanceToBeReady() {
     INSTANCE_CHECK_COUNT=$((INSTANCE_CHECK_COUNT+1))
   done
   print "  ...status check #$INSTANCE_CHECK_COUNT: READY"
+  aws ssm send-command --instance-ids "$1" --document-name "AWS-RunPatchBaseline" --comment "CMS Patch Compliance"
 }
 
 # Iterate while there are arguments

--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -84,7 +84,7 @@ function deployPreviewtoEC2() {
   aws ssm send-command \
     --targets "[{"Key":"InstanceIds","Values":["$INSTANCE_ID"]}]" \
     --document-name "AWS-RunPatchBaseline" \
-    --comment "CMS Patch Compliance
+    --comment "CMS Patch Compliance"
 
   print "• Cleaning up previous instances"
   while read -r INSTANCE_ID; do


### PR DESCRIPTION
Resolves # AWS Security Hub Findings:
EC2 instances managed by Systems Manager should have an association compliance status of COMPLIANT
EC2 instances managed by Systems Manager should have a patch compliance status of COMPLIANT after a patch installation

**Description-**
Adds a stage to the provision process that runs AWS CMS patching so that our instances are complaint from provision and don't have to wait for our monthly patch window to be brought into compliance.

**This pull request changes...**

- Adds a step to the CircleCI provisioning process
- Newly provisioned instances are complaint in AWS Security Hub.

**This pull request also touches…**

- Provisioning is weird

**This pull request was tested in the follow ways…**

- Checked CircleCI logs to make sure the step ran successfully without breaking other steps
- Checked AWS Security Hub to make sure that the newly provisioned instance was in a compliant state

**Steps to manually verify this change...**

- Check CircleCI logs to make sure the step ran successfully without breaking other steps
- Check AWS Security Hub to make sure that the newly provisioned instance are in a compliant state

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
