### PR TITLE
resolves issue with MMIS activities

### DIFF
--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -36,7 +36,7 @@ const expenseTypeNames = [
   'combined'
 ];
 
-const FFPOptions = new Set(['90-10', '75-25', '50-50']);
+const FFPOptions = new Set(['90-10', '75-25', '50-50', '0-100']);
 
 const expenseTypes = (years, names = expenseTypeNames) =>
   names.reduce(


### PR DESCRIPTION
Resolves #3749 

**Description-**
Adding a default fed-state split of 0-100 caused an unforeseen error that prevented users from adding costs or even opening an APD once it had an MMIS activity. 

**This pull request changes...**

- adds the default fed-state split of 0-100 to the object so budget calculations can be completed before a fed-state split has been specified

**This pull request was tested in the follow ways…**

- created an MMIS activity and saved some costs, then changed the fed-state split to confirm that they would be recalculated

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
