### PR TITLE
bbrooks/3540-Update_New_Relic

### DIFF
--- a/bin/preview-deploy/aws.sh
+++ b/bin/preview-deploy/aws.sh
@@ -166,7 +166,7 @@ function configureUserData() {
 #   PR_NUM - Github pull request number associated with this instance
 function createNewInstance() {
   aws ec2 run-instances \
-    --instance-type t3.large \
+    --instance-type t3.medium \
     --image-id $1 \
     --security-group-ids "$AWS_SECURITY_GROUP" \
     --subnet-id "$AWS_SUBNET" \

--- a/web/audit-ci.json
+++ b/web/audit-ci.json
@@ -1,7 +1,7 @@
 {
   "low": true,
   "package-manager": "auto",
-  "allowlist": [1005291, 1006947, 1007048],
+  "allowlist": [1005291, 1006947],
   "_comment": {
     "1005291": {
       "advisory": "https://github.com/advisories/GHSA-w5p7-h5w8-2hfq",

--- a/web/audit-ci.json
+++ b/web/audit-ci.json
@@ -1,7 +1,7 @@
 {
   "low": true,
   "package-manager": "auto",
-  "allowlist": [1005291, 1006947],
+  "allowlist": [1005291, 1006947, 1007048],
   "_comment": {
     "1005291": {
       "advisory": "https://github.com/advisories/GHSA-w5p7-h5w8-2hfq",


### PR DESCRIPTION
Resolves #3540

**Description-**
This PR is focused on updating the New Relic API Keys, which is done by variable in CircleCI. I'm leveraging this PR to also revert the instance size back to the t3.medium size that it was before the Mongo work.

**This pull request changes...**

- New Relic will use new API Key
- New Instances are provisioned at size t3.medium

**This pull request also touches…**

- possible side effects of this change

**This pull request was tested in the follow ways…**

- list of frontend cases
- list of backend cases

**Steps to manually verify this change...**

1. steps to view and verify change

### This pull request is ready to review when...

- [ ] Automated tests are updated (and all tests are passing)
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when…

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
