### PR TITLE
added endpoints for health checks for postgres and mongo

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -143,7 +143,7 @@
     "testTimeout": 30000
   },
   "resolutions": {
-    "minimist": "1.2.6"
+    "minimist": ">=1.2.6"
   },
   "packageManager": "yarn@1.22.18"
 }


### PR DESCRIPTION
Resolves #3815 

### Description
added two new heartbeat endpoints:
/heartbeat-db for postgres
/heartbeat-mongo for mongo

The endpoints will return 204 if they are connected and 503 if they aren't.

### This pull request is ready to review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
