### PR TITLE
Temp insecure certs on health check

### DIFF
--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -93,11 +93,11 @@ function deployAPItoEC2() {
 
   echo "• Checking availability of Frontend"
   if [[ $ENVIRONMENT == "production" ]]; then
-    while [[ "$(curl -s -o /dev/null -w %{http_code} https://eapd.cms.gov)" != "200" ]]; 
+    while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://eapd.cms.gov)" != "200" ]]; 
       do echo "• • Frontend currently unavailable" && sleep 60; 
     done
   elif [[ $ENVIRONMENT == "staging" ]]; then
-    while [[ "$(curl -s -o /dev/null -w %{http_code} https://staging-eapd.cms.gov)" != "200" ]]; 
+    while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://staging-eapd.cms.gov)" != "200" ]]; 
       do echo "• • Frontend currently unavailable" && sleep 60; 
     done
   else


### PR DESCRIPTION
Resolves # Broken Health Check

### Description
Our certs are expired and so the health check won't pass, this temporarily allows insecure TLS so that the health checks will pass

### Signifcant changes or possible side effects

### Automated test cases written

### Steps to manually verify this change

1.
2.
3.

### This pull request is ready to review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] Pull request has been labeled, if applicable with feature, content, bug, tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
