### PR TITLE
Removed insecure flag from curl commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,6 +496,8 @@ jobs:
             export OKTA_SERVER_ID="$PREVIEW_OKTA_SERVER_ID"
             export OKTA_CLIENT_ID="$PREVIEW_OKTA_CLIENT_ID"
             export JWT_SECRET="$PREVIEW_JWT_SECRET"
+            export TEALIUM_TAG="$PREVIEW_TEALIUM_TAG"
+            export WEB_ENV="test"
 
             echo "$DOCKER_EAPD_PW" |docker login -u $DOCKER_EAPD_UN --password-stdin
             docker-compose up -d

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -93,11 +93,11 @@ function deployAPItoEC2() {
 
   echo "• Checking availability of Frontend"
   if [[ $ENVIRONMENT == "production" ]]; then
-    while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://eapd.cms.gov)" != "200" ]]; 
+    while [[ "$(curl -s -o /dev/null -w %{http_code} https://eapd.cms.gov)" != "200" ]]; 
       do echo "• • Frontend currently unavailable" && sleep 60; 
     done
   elif [[ $ENVIRONMENT == "staging" ]]; then
-    while [[ "$(curl -k -s -o /dev/null -w %{http_code} https://staging-eapd.cms.gov)" != "200" ]]; 
+    while [[ "$(curl -s -o /dev/null -w %{http_code} https://staging-eapd.cms.gov)" != "200" ]]; 
       do echo "• • Frontend currently unavailable" && sleep 60; 
     done
   else


### PR DESCRIPTION
Resolves # Removes temporary -k curl flags

### Description
I added -k (allow insecure) to the health checks for our site when our certificates expired. We have new certs installed, so we should remove the -k flag. This removes the temporary -k curl flags.

### Signifcant changes or possible side effects

### Automated test cases written

### Steps to manually verify this change

1.
2.
3.

### This pull request is ready to review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] Pull request has been labeled, if applicable with feature, content, bug, tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
