### PR TITLE
Disables automatic building of infrastructure for Snyk PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,7 @@ workflows:
               ignore:
                 - main
                 - gh-pages
+                - snyk-upgrade-*
             tags:
               ignore: /^noinfra.*/
           requires:


### PR DESCRIPTION
Resolves # Snyk opening a load of PRs all the time.

### Description
Snyk loves to open PRs, each PR creates infrastructure, this will allow Snyk to continue to open PRs without provisioning infrastructure

### Signifcant changes or possible side effects

### Automated test cases written

### Steps to manually verify this change

1.
2.
3.

### This pull request is ready to review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] Pull request has been labeled, if applicable with feature, content, bug, tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the accessibility and functionality related to the change
- [ ] Design has approved the experience
- [ ] Product has approved the experience
