### PR TITLE
Tbolt/1741 adds dollars to costAllocation aria message

### DIFF
--- a/web/src/redux/actions/aria.js
+++ b/web/src/redux/actions/aria.js
@@ -1,15 +1,14 @@
 export const ARIA_ANNOUNCE_CHANGE = 'ARIA_ANNOUNCE_CHANGE';
 
-export const ariaAnnounceFFPQuarterly = (aKey, year, q, name) => (
-  dispatch,
-  getState
-) => {
-  dispatch({
-    type: ARIA_ANNOUNCE_CHANGE,
-    message: getState().budget.activities[aKey].quarterlyFFP[year][q][name]
-      .dollars
-  });
-};
+export const ariaAnnounceFFPQuarterly =
+  (aKey, year, q, name) => (dispatch, getState) => {
+    dispatch({
+      type: ARIA_ANNOUNCE_CHANGE,
+      message: `${
+        getState().budget.activities[aKey].quarterlyFFP[year][q][name].dollars
+      } dollars`
+    });
+  };
 
 export const ariaAnnounceApdLoading = () => ({
   type: ARIA_ANNOUNCE_CHANGE,

--- a/web/src/redux/actions/aria.test.js
+++ b/web/src/redux/actions/aria.test.js
@@ -59,7 +59,7 @@ describe('aria actions', () => {
     expect(store.getActions()).toEqual([
       {
         type: ARIA_ANNOUNCE_CHANGE,
-        message: '700'
+        message: '700 dollars'
       }
     ]);
   });


### PR DESCRIPTION
Resolves #1741 

### Description
Adds more context to the aria message when entering percents into Cost Allocation tables. Previously it would read the dollar amount number only, now it is updated to end with "dollars."


### Significant changes or possible side effects
None


### Automated test cases written
Automated test updated to reflect expected language


### Steps to manually verify this change

1. Login and view an APD that has data. Make sure there are existing costs for the cost allocation tables
2. Turn on a screen reader
3. Enter/update percentages and verify the aria announce message reads the number with "dollars" at the end.4. 


### This pull request is ready to review when

- [ ] Automated tests are updated (and all tests are passing)
- [ ] Pull request has been labeled, if applicable with feature, content, bug, tests, refactor
- [ ] Associated OpenAPI documentation has been updated
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This pull request can be merged when

- [ ] Code has been reviewed by someone other than the original author
- [ ] QA has verified the functionality related to the change
- [ ] QA has verified the accesibility using tools such as screen readers and WAVE (accessibility evaluation tool)
- [ ] Design has approved the experience
- [ ] Product has approved the experience
